### PR TITLE
feat: 사이드바, 대시보드 리스트 api 연결 및 dashboard/[id] 레이아웃

### DIFF
--- a/src/app/components/DashbaordCard.tsx
+++ b/src/app/components/DashbaordCard.tsx
@@ -2,28 +2,47 @@
 
 import Link from 'next/link';
 import Pagination from './Pagination';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { mockData } from './mockdata/DashboardMock';
 import Image from 'next/image';
 import { useModal } from '@/context/ModalContext';
 import NewDashboardModal from './modals/NewDashboardModal';
+import instance from '@/app/api/axios';
 
 type ColorPalette = {
   [key: string]: string;
 };
 
 const ColorPalette: ColorPalette = {
-  green: 'bg-custom_green-_7ac555',
-  purple: 'bg-custom_purple',
-  orange: 'bg-custom_orange',
-  blue: 'bg-custom_blue',
-  pink: 'bg-custom_pink',
+  '#7ac555': 'bg-custom_green-_7ac555',
+  '#760dde': 'bg-custom_purple',
+  '#ffa500': 'bg-custom_orange',
+  '#76a6ea': 'bg-custom_blue',
+  '#e876ea': 'bg-custom_pink',
+};
+
+type DashboardData = {
+  id: string;
+  title: string;
+  color: string;
+  createdByMe: boolean;
 };
 
 export default function DashboardCard() {
   const [currentPage, setCurrentPage] = useState(1);
-
+  const [totalCount, setTotalCount] = useState<number>(10);
+  const [dashboardsData, setDashboardsData] = useState<DashboardData[]>([]);
   const { openModal } = useModal();
+  const startIndex = (currentPage - 1) * 5; //시작페이지
+  const totalPage = Math.ceil(totalCount / 5); //마지막페이지
+
+  /** 대시보드 조회 파라미터 */
+  const queryParams = {
+    navigationMethod: 'pagination',
+    cursorId: startIndex,
+    page: currentPage,
+    size: 5,
+  };
 
   const handleOpenModal = (content: React.ReactNode) => {
     openModal(content);
@@ -41,9 +60,17 @@ export default function DashboardCard() {
     }
   };
 
-  const startIndex = (currentPage - 1) * 5;
-  const selectedTodos = mockData.slice(startIndex, startIndex + 5);
-  const totalPage = Math.ceil(mockData.length / 5);
+  /** 대시보드 조회 */
+  useEffect(() => {
+    const fetchdashboardData = async () => {
+      const res = await instance.get('dashboards', {
+        params: queryParams,
+      });
+      setDashboardsData(res.data.dashboards);
+      setTotalCount(res.data.totalCount);
+    };
+    fetchdashboardData();
+  }, [currentPage]);
 
   return (
     <section className='w-sreen ml-6 mt-6'>
@@ -61,7 +88,7 @@ export default function DashboardCard() {
             />
           </div>
         </button>
-        {selectedTodos.map((todo) => (
+        {dashboardsData.map((todo) => (
           <Link
             key={todo.id}
             href={`/dashboard/${todo.id}`}

--- a/src/app/components/DashboardHeaderInSettings.tsx
+++ b/src/app/components/DashboardHeaderInSettings.tsx
@@ -47,7 +47,7 @@ const DashboardHeaderInSettings = () => {
   }, []);
 
   return (
-    <nav className='flex h-[60px] items-center justify-between p-4'>
+    <nav className='flex h-[60px] items-center justify-between border-b p-4'>
       <div className='invisible flex items-center xl:visible'>
         <span className='text-lg font-bold'>비브리지</span>
         <span className='ml-2 text-yellow-500'>

--- a/src/app/components/DashboardListMobile.tsx
+++ b/src/app/components/DashboardListMobile.tsx
@@ -1,27 +1,46 @@
 'use client';
 import Link from 'next/link';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { mockData } from './mockdata/DashboardMock';
 import { useModal } from '@/context/ModalContext';
 import NewDashboardModal from './modals/NewDashboardModal';
+import instance from '@/app/api/axios';
 
 type ColorPalette = {
   [key: string]: string;
 };
 
 const ColorPalette: ColorPalette = {
-  green: 'bg-custom_green-_7ac555',
-  purple: 'bg-custom_purple',
-  orange: 'bg-custom_orange',
-  blue: 'bg-custom_blue',
-  pink: 'bg-custom_pink',
+  '#7ac555': 'bg-custom_green-_7ac555',
+  '#760dde': 'bg-custom_purple',
+  '#ffa500': 'bg-custom_orange',
+  '#76a6ea': 'bg-custom_blue',
+  '#e876ea': 'bg-custom_pink',
+};
+
+type DashboardData = {
+  id: string;
+  title: string;
+  color: string;
+  createdByMe: boolean;
 };
 
 export default function DashboardListMobile() {
   const [currentPage, setCurrentPage] = useState<number>(1);
+  const [totalCount, setTotalCount] = useState<number>(10);
   const startPointRef = useRef(0);
-
   const { openModal } = useModal();
+  const [dashboardsData, setDashboardsData] = useState<DashboardData[]>([]);
+  const startIndex = (currentPage - 1) * 10; //시작페이지
+  const totalPage = Math.ceil(totalCount / 10); //마지막페이지
+
+  /** 대시보드 조회 파라미터 */
+  const queryParams = {
+    navigationMethod: 'pagination',
+    cursorId: startIndex,
+    page: currentPage,
+    size: 10,
+  };
 
   const handleOpenModal = (content: React.ReactNode) => {
     openModal(content);
@@ -42,9 +61,17 @@ export default function DashboardListMobile() {
     }
   };
 
-  const startIndex = (currentPage - 1) * 10;
-  const selectedTodos = mockData.slice(startIndex, startIndex + 10);
-  const totalPage = Math.ceil(mockData.length / 10);
+  /** 대시보드 조회 */
+  useEffect(() => {
+    const fetchdashboardData = async () => {
+      const res = await instance.get('dashboards', {
+        params: queryParams,
+      });
+      setDashboardsData(res.data.dashboards);
+      setTotalCount(res.data.totalCount);
+    };
+    fetchdashboardData();
+  }, [currentPage]);
 
   return (
     <div className='p-0 px-3 sm:hidden'>
@@ -59,7 +86,7 @@ export default function DashboardListMobile() {
         </button>
       </div>
       <div onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
-        {selectedTodos.map((todo) => (
+        {dashboardsData.map((todo) => (
           <Link
             key={todo.id}
             href={`/dashboard/${todo.id}`}

--- a/src/app/components/ProfileSetting.tsx
+++ b/src/app/components/ProfileSetting.tsx
@@ -41,7 +41,10 @@ export default function ProfileSetting() {
     const reader = new FileReader();
     reader.readAsDataURL(uploadFile);
     reader.onloadend = () => {
-      setUploadedImage(reader.result as string);
+      const result = reader.result;
+      if (typeof result === 'string') {
+        setUploadedImage(result);
+      }
     };
   };
 
@@ -53,6 +56,7 @@ export default function ProfileSetting() {
 
   return (
     <form
+      onSubmit={handleSubmit(onSubmit)}
       className='mx-5 my-[25px] flex w-[620px] flex-shrink-0 flex-col gap-8 rounded-lg bg-custom_white px-7 py-7 max-xl:w-auto max-xl:max-w-[620px] max-sm:mx-3 max-sm:flex max-sm:flex-col'
     >
       <div className='font-Pretendard text-4xl font-bold text-custom_black-_333236'>

--- a/src/app/dashboard/[dashboardid]/page.tsx
+++ b/src/app/dashboard/[dashboardid]/page.tsx
@@ -4,6 +4,8 @@ import Column from '@/app/components/Column';
 import NewColumnModal from '@/app/components/modals/NewColumnModal';
 import ChipAddIcon from '@/app/components/ui/chipAddIcon';
 import { useModal } from '@/context/ModalContext';
+import SideBar from '@/app/components/SideBar';
+import DashboardHeaderInSettings from '@/app/components/DashboardHeaderInSettings';
 
 const columnMockData = {
   result: 'SUCCESS',
@@ -33,23 +35,27 @@ export default function dashboardPage() {
   };
 
   return (
-    <>
-      <div className='flex flex-wrap bg-custom_gray-_fafafa'>
-        {/* 컬럼 컴포넌트 뿌리기 */}
-        {columnMockData.data.map((column: any, index: number) => {
-          return <Column key={column.id} title={column.title} />;
-        })}
-        {/* 카드 추가하기 모달 */}
-        <button
-          className='border-gray-_d9d9d9 relative left-[20px] top-[68px] flex h-[70px] w-[354px] items-center justify-center rounded-lg border bg-white'
-          onClick={() => handleOpenModal(<NewColumnModal />)}
-        >
-          <p className='mr-[12px] text-[16px] font-bold'>
-            새로운 컬럼 추가하기
-          </p>
-          <ChipAddIcon size={'large'} />
-        </button>
+    <div className='flex'>
+      <SideBar />
+      <div className='w-screen'>
+        <DashboardHeaderInSettings />
+        <div className='flex flex-wrap bg-custom_gray-_fafafa'>
+          {/* 컬럼 컴포넌트 뿌리기 */}
+          {columnMockData.data.map((column: any, index: number) => {
+            return <Column key={column.id} title={column.title} />;
+          })}
+          {/* 카드 추가하기 모달 */}
+          <button
+            className='border-gray-_d9d9d9 relative left-[20px] top-[68px] flex h-[70px] w-[354px] items-center justify-center rounded-lg border bg-white'
+            onClick={() => handleOpenModal(<NewColumnModal />)}
+          >
+            <p className='mr-[12px] text-[16px] font-bold'>
+              새로운 컬럼 추가하기
+            </p>
+            <ChipAddIcon size={'large'} />
+          </button>
+        </div>
       </div>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
사이드바, 대시보드 리스트 api 연결하였습니다.
dashboard/[id] 페이지 레이아웃 구현했습니다.

<img width="280" alt="스크린샷 2024-06-07 오후 8 59 16" src="https://github.com/codeit-project-9/taskify/assets/159985297/2bd9bb27-fcd6-4506-a366-99f84f7b59a4">
api 연결
<img width="1416" alt="스크린샷 2024-06-07 오후 10 20 01" src="https://github.com/codeit-project-9/taskify/assets/159985297/ea147a93-2fe3-4abb-906f-44716f6cae1b"></br>
페이지 레이아웃