### PR TITLE
feat: 대시보드리스트 컨텍스트 추가 및 구성원 및 초대내역 삭제 시 바로 반영

### DIFF
--- a/src/app/(dashboard)/dashboard/[dashboardid]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/[dashboardid]/edit/page.tsx
@@ -28,11 +28,11 @@ export default function dashboardEditPage({ params }: PageProps) {
   /** 대시보드 삭제 */
   const onClick = async () => {
     try {
-      const response = await instance.delete(backLink);
+      const response = await instance.delete(`/dashboards/${dashboardid}`);
       handleOpenModal(
         <SettingChangedModal>대시보드가 삭제되었습니다.</SettingChangedModal>,
       );
-      router.push('/');
+      router.push('/mydashboard');
     } catch (e: unknown) {
       <SettingChangedModal>
         대시보드가 삭제에 실패하였습니다.

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -23,7 +23,7 @@ const DashboardLayout: React.FC<LayoutProps> = ({ children }) => {
     ) {
       return <DashboardHeaderInSettings link={dashboardId} />;
     } else if (pathname.endsWith('/edit')) {
-      return <DashboardHeaderInSettings link={''} />;
+      return <DashboardHeaderInSettings />;
     } else if (pathname === '/mypage') {
       return <DashboardHeader title={'계정관리'} />;
     } else {

--- a/src/app/components/DashboardCard.tsx
+++ b/src/app/components/DashboardCard.tsx
@@ -30,7 +30,7 @@ type DashboardData = {
 export default function DashboardCard() {
   const [currentPage, setCurrentPage] = useState(1); //현재 페이지
   const [totalCount, setTotalCount] = useState<number>(10); //총 페이지
-  const [dashboardsData, setDashboardsData] = useState<DashboardData[]>([]); // 가져올 대시보드 데이터
+  const [dashboardsData, setDashboardsData] = useState<DashboardData[]>([]);
   const { openModal } = useModal();
   const startIndex = (currentPage - 1) * 5; //시작페이지
   const totalPage = Math.ceil(totalCount / 5); //마지막페이지

--- a/src/app/components/DashboardList.tsx
+++ b/src/app/components/DashboardList.tsx
@@ -6,6 +6,7 @@ import Pagination from './Pagination';
 import Image from 'next/image';
 import { useModal } from '@/context/ModalContext';
 import NewDashboardModal from './modals/NewDashboardModal';
+import { useDashboardData } from '@/context/DashboardDataContext';
 import instance from '@/app/api/axios';
 
 type ColorPalette = {
@@ -20,17 +21,10 @@ const ColorPalette: ColorPalette = {
   '#e876ea': 'bg-custom_pink',
 };
 
-type DashboardData = {
-  id: string;
-  title: string;
-  color: string;
-  createdByMe: boolean;
-};
-
 export default function DashboardList() {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [totalCount, setTotalCount] = useState<number>(10);
-  const [dashboardsData, setDashboardsData] = useState<DashboardData[]>([]);
+  const { dashboardsData, setDashboardsData } = useDashboardData();
   const { openModal } = useModal();
   const startIndex = (currentPage - 1) * 10; //시작페이지
   const totalPage = Math.ceil(totalCount / 10); //마지막페이지

--- a/src/app/components/InvitationList.tsx
+++ b/src/app/components/InvitationList.tsx
@@ -69,7 +69,6 @@ export default function InvitationList({
       const res = await instance.get(`dashboards/${dashboardid}/invitations`, {
         params: queryParams,
       });
-      console.log(res);
       setInvitationList(res.data.invitations);
       setTotalCount(res.data.totalCount);
     };

--- a/src/app/components/InvitationList.tsx
+++ b/src/app/components/InvitationList.tsx
@@ -46,9 +46,14 @@ export default function InvitationList({
     const link = `dashboards/${dashboardid}/invitations/${id}`;
     try {
       const response = await instance.delete(link);
-      handleOpenModal(
-        <SettingChangedModal>초대가 취소되었습니다.</SettingChangedModal>,
-      );
+      if (response.status >= 200 && response.status < 300) {
+        handleOpenModal(
+          <SettingChangedModal>초대가 취소되었습니다.</SettingChangedModal>,
+        );
+        setInvitationList(
+          (prev) => prev?.filter((invitation) => invitation.id !== id) || null,
+        );
+      }
     } catch (e: unknown) {
       //변경실패시
       if (axios.isAxiosError(e)) {

--- a/src/app/components/InvitationList.tsx
+++ b/src/app/components/InvitationList.tsx
@@ -78,7 +78,6 @@ export default function InvitationList({
   return (
     <div className='m-5 w-[620px] rounded-lg bg-custom_white max-xl:w-auto max-xl:max-w-[620px] max-sm:mx-3'>
       <div className='relative flex'>
-        {}
         <EditMenuTitle
           title='초대 내역'
           subtitle='이메일'

--- a/src/app/components/MemberList.tsx
+++ b/src/app/components/MemberList.tsx
@@ -7,6 +7,7 @@ import { CheckMembersRes } from '../api/apiTypes/membersType';
 import SettingChangedModal from './modals/SettingChangedModal';
 import { useModal } from '@/context/ModalContext';
 import axios from 'axios';
+import CustomAvatar from './CustomAvatar';
 
 export default function MemberList({ dashboardid }: { dashboardid: number }) {
   const [currentPage, setCurrentPage] = useState(1);
@@ -67,6 +68,8 @@ export default function MemberList({ dashboardid }: { dashboardid: number }) {
     fetchMembersData();
   }, []);
 
+  console.log(memberList);
+
   return (
     <div className='m-5 w-[620px] rounded-lg bg-custom_white max-xl:w-auto max-xl:max-w-[620px] max-sm:mx-3'>
       <EditMenuTitle
@@ -86,13 +89,11 @@ export default function MemberList({ dashboardid }: { dashboardid: number }) {
                 className='text-black-_333236 stroke-gray-_eeeeee flex flex-shrink-0 items-center justify-between border-b stroke-1 py-4'
               >
                 <div className='flex items-center gap-3 max-sm:text-sm'>
-                  <div className='relative h-[38px] w-[38px]'>
-                    <Image
-                      fill
-                      src='/images/mockprofile4.svg'
-                      alt='프로필 사진'
-                    />
-                  </div>
+                  <CustomAvatar
+                    profileUrl={member.profileImageUrl}
+                    nickName={member.nickname}
+                    size='medium'
+                  />
                   {member.nickname}
                 </div>
                 <button

--- a/src/app/components/MemberList.tsx
+++ b/src/app/components/MemberList.tsx
@@ -38,9 +38,14 @@ export default function MemberList({ dashboardid }: { dashboardid: number }) {
   const onClick = async (id: number) => {
     try {
       const response = await instance.delete(`members/${id}`);
-      handleOpenModal(
-        <SettingChangedModal>멤버가 삭제되었습니다.</SettingChangedModal>,
-      );
+      if (response.status >= 200 && response.status < 300) {
+        handleOpenModal(
+          <SettingChangedModal>멤버가 삭제되었습니다.</SettingChangedModal>,
+        );
+        setMemberList(
+          (prev) => prev?.filter((member) => member.id !== id) || null,
+        );
+      }
     } catch (e: unknown) {
       //변경실패시
       if (axios.isAxiosError(e)) {

--- a/src/app/components/modals/NewDashboardModal.tsx
+++ b/src/app/components/modals/NewDashboardModal.tsx
@@ -3,10 +3,12 @@
 import { useState } from 'react';
 import { useModal } from '@/context/ModalContext';
 import { useRouter } from 'next/navigation';
+import { useDashboardData } from '@/context/DashboardDataContext';
 import instance from '@/app/api/axios';
 
 const NewDashboardModal: React.FC = () => {
   const router = useRouter();
+  const { dashboardsData, setDashboardsData } = useDashboardData();
   const { closeModal } = useModal();
   const [selectedColor, setSelectedColor] = useState<string>('#7ac555');
   const [dashboardName, setDashboardName] = useState<string>('');
@@ -44,6 +46,12 @@ const NewDashboardModal: React.FC = () => {
       const response = await instance.post('dashboards', requestData);
       if (response.status >= 200 && response.status < 300) {
         console.log('POST 요청 성공:', response.data);
+        setDashboardsData((prev) => {
+          const newData = [...prev];
+          newData.pop();
+          newData.unshift(response.data);
+          return newData;
+        });
         router.push(`/dashboard/${response.data.id}`);
       }
     } catch (e) {

--- a/src/app/components/modals/NewDashboardModal.tsx
+++ b/src/app/components/modals/NewDashboardModal.tsx
@@ -2,9 +2,11 @@
 
 import { useState } from 'react';
 import { useModal } from '@/context/ModalContext';
+import { useRouter } from 'next/navigation';
 import instance from '@/app/api/axios';
 
 const NewDashboardModal: React.FC = () => {
+  const router = useRouter();
   const { closeModal } = useModal();
   const [selectedColor, setSelectedColor] = useState<string>('#7ac555');
   const [dashboardName, setDashboardName] = useState<string>('');
@@ -40,7 +42,10 @@ const NewDashboardModal: React.FC = () => {
   const onClick = async () => {
     try {
       const response = await instance.post('dashboards', requestData);
-      console.log('POST 요청 성공:', response.data);
+      if (response.status >= 200 && response.status < 300) {
+        console.log('POST 요청 성공:', response.data);
+        router.push(`/dashboard/${response.data.id}`);
+      }
     } catch (e) {
       alert('대시보드 생성에 실패했습니다.');
     } finally {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import './globals.css';
 import { ModalProvider } from '@/context/ModalContext';
+import { DashboardDataProvider } from '@/context/DashboardDataContext';
 import CommonModal from './components/modals/CommonModal';
 
 export default function RootLayout({
@@ -11,8 +12,10 @@ export default function RootLayout({
     <html lang='ko'>
       <body>
         <ModalProvider>
-          {children}
-          <CommonModal />
+          <DashboardDataProvider>
+            {children}
+            <CommonModal />
+          </DashboardDataProvider>
         </ModalProvider>
       </body>
     </html>

--- a/src/context/DashboardDataContext.tsx
+++ b/src/context/DashboardDataContext.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface DashboardDataContextProps {
+  id: string;
+  title: string;
+  color: string;
+  createdByMe: boolean;
+}
+
+interface DashboardDataProviderProps {
+  children: ReactNode;
+}
+
+interface DashboardDataContextType {
+  dashboardsData: DashboardDataContextProps[];
+  setDashboardsData: React.Dispatch<
+    React.SetStateAction<DashboardDataContextProps[]>
+  >;
+  dashboardCard: DashboardDataContextProps[];
+  setDashboardCard: React.Dispatch<
+    React.SetStateAction<DashboardDataContextProps[]>
+  >;
+}
+
+// 대시보드 데이터 컨텍스트 생성
+const DashboardDataContext = createContext<
+  DashboardDataContextType | undefined
+>(undefined);
+
+// 대시보드 데이터 제공자 컴포넌트
+export const DashboardDataProvider = ({
+  children,
+}: DashboardDataProviderProps) => {
+  const [dashboardsData, setDashboardsData] = useState<
+    DashboardDataContextProps[]
+  >([]);
+  const [dashboardCard, setDashboardCard] = useState<
+    DashboardDataContextProps[]
+  >([]);
+
+  return (
+    <DashboardDataContext.Provider
+      value={{
+        dashboardsData,
+        setDashboardsData,
+        dashboardCard,
+        setDashboardCard,
+      }}
+    >
+      {children}
+    </DashboardDataContext.Provider>
+  );
+};
+
+// 대시보드 데이터를 사용하기 위한 Hook
+export const useDashboardData = () => {
+  const context = useContext(DashboardDataContext);
+  if (context === undefined) {
+    throw new Error(
+      'useDashboardData must be used within a DashboardDataProvider',
+    );
+  }
+  return context;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,7 +26,8 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
-    "api/axios.js"
+    "api/axios.js",
+    "src/context/DashboardDataContext.ㅓsx"
   ],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
새로운 대시보드 추가 시 대시보드 페이지로 리다이렉트 및 사이드바에 바로 적용되도록 구현하였습니다.
대시보드 글자 줄이기 기능은 구현 예정입니다.
구성원 삭제 및 초대내역 삭제시 바로 반영되게 만들었습니다.


<img width="906" alt="스크린샷 2024-06-11 오후 11 37 53" src="https://github.com/codeit-project-9/taskify/assets/159985297/f4da3125-7314-4099-bc2b-2e001e147a78">
<img width="914" alt="스크린샷 2024-06-11 오후 11 37 59" src="https://github.com/codeit-project-9/taskify/assets/159985297/680e53da-22c7-408f-b694-bab63ab8286e">
