### PR TITLE
Feat: dashboard페이지 api연결

### DIFF
--- a/src/app/(dashboard)/dashboard/[dashboardid]/page.tsx
+++ b/src/app/(dashboard)/dashboard/[dashboardid]/page.tsx
@@ -45,9 +45,10 @@ export default function dashboardPage(dashboardid: any) {
               columnData.map((column: any, index: number) => {
                 return (
                   <Column
-                    key={column.id}
+                    key={index}
                     columnId={column.id}
                     title={column.title}
+                    dashboardId={id}
                   />
                 );
               })}

--- a/src/app/(dashboard)/dashboard/[dashboardid]/page.tsx
+++ b/src/app/(dashboard)/dashboard/[dashboardid]/page.tsx
@@ -9,6 +9,7 @@ import { getColumnsByDashBoardId } from '@/app/components/ToDoCardModal/api';
 
 export default function dashboardPage(dashboardid: any) {
   const [columnData, setColumnData] = useState([]);
+  const [columnTitles, setColumnTitles] = useState([]);
   const { openModal } = useModal();
 
   const id = Number(dashboardid.params.dashboardid);
@@ -21,6 +22,9 @@ export default function dashboardPage(dashboardid: any) {
     try {
       const columnData = await getColumnsByDashBoardId(id);
       setColumnData(columnData.data);
+
+      const titles = columnData.data.map((column: any) => column.title);
+      setColumnTitles(titles);
     } catch (error) {
       console.error(error);
     }
@@ -29,42 +33,6 @@ export default function dashboardPage(dashboardid: any) {
   useEffect(() => {
     fetchColumns();
   }, []);
-
-  /* 새로운 컬럼 생성 버튼 - PC */
-  const NewColumnButton = useMemo(() => {
-    return (
-      <div className='ml-[20px] mt-[68px] min-w-[354px] max-xl:hidden'>
-        <div
-          className='border-gray-_d9d9d9 flex h-[70px] items-center justify-center rounded-lg border bg-white max-xl:ml-[0px] max-xl:mt-[0px]'
-          onClick={() => handleOpenModal(<NewColumnModal dashboardId={id} />)}
-        >
-          <p className='mr-[12px] text-[16px] font-bold'>
-            새로운 컬럼 추가하기
-          </p>
-          <ChipAddIcon size={'large'} />
-        </div>
-      </div>
-    );
-  }, [handleOpenModal]);
-
-  /* 새로운 컬럼 생성 버튼 - Tablet, Mobile */
-  const NewColumnButtonMedia = useMemo(() => {
-    return (
-      <div className='hidden max-xl:fixed max-xl:bottom-0 max-xl:block max-xl:w-full max-xl:bg-custom_gray-_fafafa max-xl:px-[20px]'>
-        <div
-          className='border-gray-_d9d9d9 ml-[20px] mt-[68px] flex h-[70px] items-center justify-center rounded-lg border bg-white max-xl:ml-[0px] max-xl:mt-[0px]'
-          onClick={() =>
-            handleOpenModal(<NewColumnModal dashboardId={dashboardid} />)
-          }
-        >
-          <p className='mr-[12px] text-[16px] font-bold'>
-            새로운 컬럼 추가하기
-          </p>
-          <ChipAddIcon size={'large'} />
-        </div>
-      </div>
-    );
-  }, [handleOpenModal]);
 
   return (
     <>
@@ -83,10 +51,24 @@ export default function dashboardPage(dashboardid: any) {
                   />
                 );
               })}
-            {NewColumnButton}
+            <div
+              className='border-gray-_d9d9d9 ml-[20px] mt-[68px] flex h-[70px] min-w-[354px] items-center justify-center rounded-lg border bg-white max-xl:ml-[0px] max-xl:mt-[0px]'
+              onClick={() =>
+                handleOpenModal(
+                  <NewColumnModal
+                    dashboardId={id}
+                    columnTitles={columnTitles}
+                  />,
+                )
+              }
+            >
+              <p className='mr-[12px] text-[16px] font-bold'>
+                새로운 컬럼 추가하기
+              </p>
+              <ChipAddIcon size={'large'} />
+            </div>
           </div>
         </div>
-        {NewColumnButtonMedia}
       </div>
     </>
   );

--- a/src/app/(dashboard)/dashboard/[dashboardid]/page.tsx
+++ b/src/app/(dashboard)/dashboard/[dashboardid]/page.tsx
@@ -36,9 +36,9 @@ export default function dashboardPage(dashboardid: any) {
 
   return (
     <>
-      <div className='flex bg-custom_gray-_fafafa'>
-        <div className='flex min-w-0 max-w-full flex-1 overflow-x-auto'>
-          <div className='flex flex-nowrap'>
+      <div className='relative flex'>
+        <div className='w-screen'>
+          <div className='flex overflow-x-auto whitespace-nowrap bg-custom_gray-_fafafa max-xl:flex-col max-xl:overflow-x-visible max-xl:whitespace-normal'>
             {/* 컬럼 컴포넌트 뿌리기 */}
             {columnData &&
               columnData.length > 0 &&

--- a/src/app/components/Column.tsx
+++ b/src/app/components/Column.tsx
@@ -5,59 +5,42 @@ import Image from 'next/image';
 import ChipAddIcon from './ui/chipAddIcon';
 import { useModal } from '@/context/ModalContext';
 import UpdateColumnModal from './modals/UpdateColumnModal';
-
-const cardsMockDataByColumnId = {
-  cursorId: 0,
-  totalCount: 3,
-  cards: [
-    {
-      id: 0,
-      title: '새로운 일정 관리 Taskify',
-      description: '안녕하세요!',
-      tags: ['프로젝트', '백엔드'],
-      dueDate: '2024-05-31',
-      assignee: {
-        profileImageUrl: '',
-        nickname: 'string',
-        id: 0,
-      },
-      teamId: 'string',
-      columnId: 0,
-      createdAt: '2024-05-31T16:45:45.608Z',
-      updatedAt: '2024-05-31T16:45:45.608Z',
-    },
-    {
-      id: 1,
-      title: 'string',
-      description: 'string',
-      tags: ['백엔드', '상'],
-      dueDate: '2024-05-31',
-      assignee: {
-        profileImageUrl: '/images/test/profile-test.jpeg',
-        nickname: 'string',
-        id: 0,
-      },
-      imageUrl: '/images/test/card-image-test.jpg',
-      teamId: 'string',
-      columnId: 0,
-      createdAt: '2024-05-31T16:45:45.608Z',
-      updatedAt: '2024-05-31T16:45:45.608Z',
-    },
-  ],
-};
+import { useEffect, useState } from 'react';
+import { getCardsByColumnId } from './ToDoCardModal/api';
 
 export default function Column({
   title,
   columnId,
+  dashboardId,
 }: {
   title: string;
   columnId: number;
+  dashboardId: number;
 }) {
+  const [cards, setCards] = useState<string[]>([]);
+  const [totalCount, setTotalCount] = useState<number>();
   const { openModal } = useModal();
 
   const handleOpenModal = (content: React.ReactNode) => {
     openModal(content);
   };
+
+  const fetchCards = async () => {
+    try {
+      const res = await getCardsByColumnId(columnId);
+      console.log(res);
+      setCards(res.cards);
+      setTotalCount(res.totalCount);
+    } catch (error: any) {
+      console.log(error);
+    }
+  };
+
+  console.log(cards);
+
+  useEffect(() => {
+    fetchCards();
+  }, []);
 
   return (
     <div className='border-gray-_eeeeee flex min-w-[354px] flex-col gap-[25px] border-r p-[20px] max-xl:w-full'>
@@ -71,7 +54,7 @@ export default function Column({
           />
           <span className='mr-[12px]'>{title}</span>
           <div className='flex h-[20px] w-[20px] items-center justify-center rounded bg-custom_gray-_eeeeee text-center text-[12px] font-normal text-custom_gray-_787486'>
-            <p>{cardsMockDataByColumnId.totalCount}</p>
+            <p>{totalCount}</p>
           </div>
         </div>
         <Image
@@ -93,19 +76,23 @@ export default function Column({
           <ChipAddIcon size={'large'} />
         </div>
         {/* 카드 배열 뿌리기 */}
-        {cardsMockDataByColumnId.cards.map((card: any, index: number) => {
-          return (
-            <ColumnCard
-              key={index}
-              imageUrl={card.imageUrl}
-              title={card.title}
-              tags={card.tags}
-              dueDate={card.dueDate}
-              assignerNickname={card.assignee.nickname}
-              assignerProfileUrl={card.assignee.profileImageUrl}
-            />
-          );
-        })}
+        {cards &&
+          cards.map((card: any, index: number) => {
+            return (
+              <ColumnCard
+                columnId={columnId}
+                dashboardId={dashboardId}
+                key={index}
+                imageUrl={card.imageUrl}
+                title={card.title}
+                tags={card.tags}
+                description={card.description}
+                dueDate={card.dueDate}
+                assigner={card.assignee}
+                cardId={card.id}
+              />
+            );
+          })}
       </div>
     </div>
   );

--- a/src/app/components/ColumnCard.tsx
+++ b/src/app/components/ColumnCard.tsx
@@ -3,44 +3,30 @@
 import Image from 'next/image';
 import CustomAvatar from './CustomAvatar';
 import ToDoCardModal from './modals/ToDoCardModal';
-import { CreateCardRes } from '../api/apiTypes/cardType';
 import { useModal } from '@/context/ModalContext';
 
 interface ColumnCardProps {
   imageUrl: string;
   title: string;
   tags: string[];
+  description: string;
   dueDate: string;
-  assignerNickname: string;
-  assignerProfileUrl: string;
+  assigner: any;
+  cardId: number;
+  columnId: number;
+  dashboardId: number;
 }
 
-const mockCardData: CreateCardRes = {
-  id: 0,
-  title: '새로운 일정 관리 Taskify',
-  description:
-    'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum finibus nibh arcu, quis consequat ante cursus eget. Cras mattis, nulla non laoreet porttitor, diam justo laoreet eros, vel aliquet diam elit at leo!',
-  tags: ['프로젝트', '백엔드'],
-  dueDate: '2024-05-31',
-  assignee: {
-    profileImageUrl: '',
-    nickname: 'string',
-    id: 0,
-  },
-  imageUrl: '/images/test/card-image-test.jpg',
-  teamId: 'string',
-  columnId: 0,
-  createdAt: '2024-05-31T16:45:45.608Z',
-  updatedAt: '2024-05-31T16:45:45.608Z',
-};
-
 export default function ColumnCard({
+  dashboardId,
+  cardId,
+  description,
   imageUrl,
   title,
   tags,
   dueDate,
-  assignerNickname,
-  assignerProfileUrl,
+  assigner,
+  columnId,
 }: ColumnCardProps) {
   const { openModal } = useModal();
 
@@ -54,12 +40,15 @@ export default function ColumnCard({
       onClick={() =>
         handleOpenModal(
           <ToDoCardModal
-            title={mockCardData.title}
-            description={mockCardData.description}
-            tags={mockCardData.tags}
-            dueDate={mockCardData.dueDate}
-            assignee={mockCardData.assignee}
-            imageUrl={mockCardData.imageUrl}
+            columnId={columnId}
+            dashboardId={dashboardId}
+            cardId={cardId}
+            title={title}
+            description={description}
+            tags={tags}
+            dueDate={dueDate}
+            assigner={assigner}
+            imageUrl={imageUrl}
           />,
         )
       }
@@ -98,8 +87,8 @@ export default function ColumnCard({
               {dueDate}
             </div>
             <CustomAvatar
-              nickName={assignerNickname}
-              profileUrl={assignerProfileUrl}
+              nickName={assigner.nickname}
+              profileUrl={assigner.profileImageUrl}
             />
           </div>
         </div>

--- a/src/app/components/ModalFooterButtons.tsx
+++ b/src/app/components/ModalFooterButtons.tsx
@@ -10,11 +10,13 @@ import { useModal } from '@/context/ModalContext';
 const ModalFooterButtons = ({
   actionName = '생성',
   onAction,
+  onCancel,
   value,
   isDisabled = value,
 }: {
   actionName?: string;
   onAction?: () => void;
+  onCancel?: () => void;
   value?: string | boolean;
   isDisabled?: any;
 }) => {
@@ -26,7 +28,7 @@ const ModalFooterButtons = ({
       <button
         type='button'
         className={`${modalButtonStyle} bg-white text-[#787486]`}
-        onClick={closeModal}
+        onClick={onCancel || closeModal}
       >
         취소
       </button>

--- a/src/app/components/ModalInput.tsx
+++ b/src/app/components/ModalInput.tsx
@@ -16,12 +16,14 @@ const ModalInput = ({
   placeFolder,
   value,
   setValue,
+  error,
 }: {
   labelName: string;
   inputId: string;
   placeFolder: string;
   value: any;
   setValue: any;
+  error?: any;
 }) => {
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newvalue = e.target.value;
@@ -43,6 +45,7 @@ const ModalInput = ({
         onChange={handleChange}
         placeholder={placeFolder}
       />
+      {error}
     </div>
   );
 };

--- a/src/app/components/ToDoCardModal/CardHeader.tsx
+++ b/src/app/components/ToDoCardModal/CardHeader.tsx
@@ -2,7 +2,7 @@ import { useModal } from '@/context/ModalContext';
 import ToDoCardDropDown from './ToDoCardDropDown';
 import { useState } from 'react';
 
-const CardHeader = ({ title }: { title: string }) => {
+const CardHeader = ({ title, cardId }: { title: string; cardId: number }) => {
   const [isOpen, setIsOpen] = useState<boolean>(false);
   const { closeModal } = useModal();
 
@@ -23,7 +23,7 @@ const CardHeader = ({ title }: { title: string }) => {
             className='max-sm:h-[20px] max-sm:w-[20px]'
           />
         </button>
-        <ToDoCardDropDown isOpen={isOpen} />
+        <ToDoCardDropDown isOpen={isOpen} cardId={cardId} />
         <button onClick={closeModal}>
           <img
             src='/images/close-button.svg'

--- a/src/app/components/ToDoCardModal/Comment.tsx
+++ b/src/app/components/ToDoCardModal/Comment.tsx
@@ -1,11 +1,19 @@
 import { ChangeEvent, useState } from 'react';
+import { deleteColumnByID, deleteComment, putComment } from './api';
 
 interface CommentProps {
   createdAt: string;
   content: string;
+  commentId: number;
+  commenterName: string;
 }
 
-const Comment = ({ createdAt, content }: CommentProps) => {
+const Comment = ({
+  createdAt,
+  content,
+  commentId,
+  commenterName,
+}: CommentProps) => {
   const [value, setValue] = useState(content);
   const [isEditing, setIsEditing] = useState(false);
 
@@ -14,13 +22,18 @@ const Comment = ({ createdAt, content }: CommentProps) => {
   };
 
   const handleSubmit = (e: ChangeEvent<HTMLFormElement>) => {
-    setIsEditing(false);
     e.preventDefault();
+    setIsEditing(false);
+    putComment(commentId, value);
   };
 
   const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
     const newValue = e.target.value;
     setValue(newValue);
+  };
+
+  const handleDelete = () => {
+    deleteComment(commentId);
   };
 
   const cancelEdit = () => {
@@ -31,7 +44,7 @@ const Comment = ({ createdAt, content }: CommentProps) => {
   return (
     <div className='w-full text-[14px] max-sm:text-[12px]'>
       <div className='mt-[6px] flex items-center gap-[8px]'>
-        <span className='font-semibold'>장만철</span>
+        <span className='font-semibold'>{commenterName}</span>
         <span className='text-[12px] text-[#9FA6B2] max-sm:text-[10px]'>
           {createdAt}
         </span>
@@ -56,7 +69,7 @@ const Comment = ({ createdAt, content }: CommentProps) => {
         ) : (
           <button onClick={handleOnClick}>수정</button>
         )}
-        <button>삭제</button>
+        <button onClick={handleDelete}>삭제</button>
       </div>
     </div>
   );

--- a/src/app/components/ToDoCardModal/CommentInput.tsx
+++ b/src/app/components/ToDoCardModal/CommentInput.tsx
@@ -1,20 +1,35 @@
 'use client';
 
 import React, { ChangeEvent, useState } from 'react';
+import { postComment } from './api';
 
 const modalButtonStyle =
   'text-center w-[83px] h-[32px] text-[12px] rounded-md bg-white text-[#5534DA] border border-[#D9D9D9] absolute right-[10px] bottom-[15px]';
 
-const CommentInput = () => {
+const CommentInput = ({
+  columnId,
+  dashboardId,
+  cardId,
+}: {
+  columnId: number;
+  dashboardId: number;
+  cardId: number;
+}) => {
   const [value, setValue] = useState<string>('');
+  console.log(columnId, dashboardId);
 
   const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     const newvalue = e.target.value;
     setValue(newvalue);
   };
 
+  const handleSubmit = (e: any) => {
+    e.preventDefault();
+    postComment(value, cardId, columnId, dashboardId);
+  };
+
   return (
-    <form className='relative'>
+    <form className='relative' onSubmit={handleSubmit}>
       <label className='text-[16px] font-medium max-sm:text-[14px]'>댓글</label>
       <textarea
         onChange={handleChange}

--- a/src/app/components/ToDoCardModal/CommentsList.tsx
+++ b/src/app/components/ToDoCardModal/CommentsList.tsx
@@ -3,18 +3,13 @@ import { CreateCommentRes } from '@/app/api/apiTypes/commentsType';
 import CustomAvatar from '../CustomAvatar';
 import Comment from './Comment';
 
-export default function CommentsList({
-  comments,
-}: {
-  comments: CreateCommentRes[];
-}) {
+export default function CommentsList({ comments }: { comments: string[] }) {
   // 아래 state는 api적용 이후 수정 예정입니다.
-  const [nowComments, setNowComments] = useState(comments);
   const isMobile = window.innerWidth < 768;
-
+  console.log(comments);
   return (
     <div className='flex flex-col'>
-      {nowComments.map((comment: any, index: number) => {
+      {comments.map((comment: any, index: number) => {
         return (
           <div key={index} className='flex gap-[12px]'>
             <div className='flex flex-col items-center'>
@@ -24,11 +19,16 @@ export default function CommentsList({
                 size={isMobile ? 'small' : 'medium'}
               />
               {/* 댓글이 1개면 구분선을 붙이지 않습니다 */}
-              {nowComments.length > 1 && (
+              {comments.length > 1 && (
                 <div className='my-[5px] h-[40px] w-[1px] bg-gray-300'></div>
               )}
             </div>
-            <Comment createdAt={comment.createdAt} content={comment.content} />
+            <Comment
+              commentId={comment.id}
+              createdAt={comment.createdAt}
+              content={comment.content}
+              commenterName={comment.author.nickname}
+            />
           </div>
         );
       })}

--- a/src/app/components/ToDoCardModal/ToDoCardDropDown.tsx
+++ b/src/app/components/ToDoCardModal/ToDoCardDropDown.tsx
@@ -1,11 +1,29 @@
-export default function ToDoCardDropDown({ isOpen }: { isOpen: boolean }) {
+import { useModal } from '@/context/ModalContext';
+import DeleteCardModal from '../modals/DeleteCardModal';
+
+export default function ToDoCardDropDown({
+  isOpen,
+  cardId,
+}: {
+  isOpen: boolean;
+  cardId: number;
+}) {
+  const { openModal } = useModal();
+
+  const handleOpenModal = (content: React.ReactNode) => {
+    openModal(content);
+  };
+
   return (
     isOpen && (
       <div className='absolute right-[40px] top-[40px] flex w-[93px] flex-col items-center justify-center gap-[6px] rounded-md border border-[#D9D9D9] bg-white p-[6px] text-[14px] shadow-lg'>
-        <button className=''>
-          <p className={buttonStyle}>수정하기</p>
-        </button>
         <button className={buttonStyle}>
+          <p>수정하기</p>
+        </button>
+        <button
+          className={buttonStyle}
+          onClick={() => handleOpenModal(<DeleteCardModal cardId={cardId} />)}
+        >
           <span>삭제하기</span>
         </button>
       </div>

--- a/src/app/components/ToDoCardModal/api.tsx
+++ b/src/app/components/ToDoCardModal/api.tsx
@@ -22,13 +22,18 @@ const getColumnsByDashBoardId = async (dashboardid: number) => {
   }
 };
 
-const postNewColumnData = async (title: string, dashboardid: number) => {
-  const data = {
-    title: title,
-    dashboardId: dashboardid,
-  };
+const getCardsByColumnId = async (columId: number) => {
+  const res = await instance.get(`cards`, {
+    params: { columnId: `${columId}` },
+  });
+  return res.data;
+};
 
-  const res = await instance.post(`columns`, data);
+const getCommentsByCardId = async (cardId: number) => {
+  const res = await instance.get(`comments`, {
+    params: { cardId: `${cardId}` },
+  });
+  return res.data;
 };
 
 const getCardsList = async (
@@ -57,6 +62,14 @@ const deleteColumnByID = async (columnId: number) => {
   }
 };
 
+const deleteComment = async (commentId: number) => {
+  try {
+    const res = await instance.delete(`comments/${commentId}`);
+  } catch (error) {
+    console.log(error);
+  }
+};
+
 const putColumnByID = async (columnId: number, title: string) => {
   const data = { title: title };
   try {
@@ -66,11 +79,54 @@ const putColumnByID = async (columnId: number, title: string) => {
   }
 };
 
+const postComment = async (
+  content: string,
+  cardId: number,
+  columnId: number,
+  dashboardId: number,
+) => {
+  const data = {
+    content: content,
+    cardId: cardId,
+    columnId: columnId,
+    dashboardId: dashboardId,
+  };
+  console.log(data);
+  try {
+    const res = await instance.post('comments', data);
+  } catch (err) {
+    console.log(err);
+  }
+};
+
+const putComment = async (commentId: number, content: string) => {
+  const data = { content: content };
+  try {
+    const res = await instance.put(`comments/${commentId}`, data);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
+const getMyUserData = async () => {
+  try {
+    const res = await instance.get('users/me');
+    console.log(res.data);
+  } catch (error) {
+    console.error(error);
+  }
+};
+
 export {
   getDashBoard,
+  getMyUserData,
   getColumnsByDashBoardId,
-  postNewColumnData,
   getCardsList,
   deleteColumnByID,
   putColumnByID,
+  getCardsByColumnId,
+  getCommentsByCardId,
+  postComment,
+  putComment,
+  deleteComment,
 };

--- a/src/app/components/ToDoCardModal/api.tsx
+++ b/src/app/components/ToDoCardModal/api.tsx
@@ -70,6 +70,14 @@ const deleteComment = async (commentId: number) => {
   }
 };
 
+const deleteCard = async (cardId: number) => {
+  try {
+    const res = await instance.delete(`cards/${cardId}`);
+  } catch (error) {
+    console.log(error);
+  }
+};
+
 const putColumnByID = async (columnId: number, title: string) => {
   const data = { title: title };
   try {
@@ -129,4 +137,5 @@ export {
   postComment,
   putComment,
   deleteComment,
+  deleteCard,
 };

--- a/src/app/components/ToDoCardModal/api.tsx
+++ b/src/app/components/ToDoCardModal/api.tsx
@@ -29,7 +29,8 @@ const postNewColumnData = async (title: string, dashboardid: number) => {
 
   try {
     const res = await instance.post(`columns`, data);
-    return await res.data;
+    console.log(res.data);
+    return res.data;
   } catch (error) {
     console.error(error);
   }

--- a/src/app/components/ToDoCardModal/api.tsx
+++ b/src/app/components/ToDoCardModal/api.tsx
@@ -1,3 +1,4 @@
+import axios from 'axios';
 import instance from '@/app/api/axios';
 
 const getDashBoard = async () => {
@@ -27,13 +28,7 @@ const postNewColumnData = async (title: string, dashboardid: number) => {
     dashboardId: dashboardid,
   };
 
-  try {
-    const res = await instance.post(`columns`, data);
-    console.log(res.data);
-    return res.data;
-  } catch (error) {
-    console.error(error);
-  }
+  const res = await instance.post(`columns`, data);
 };
 
 const getCardsList = async (
@@ -67,7 +62,7 @@ const putColumnByID = async (columnId: number, title: string) => {
   try {
     const res = await instance.put(`columns/${columnId}`, data);
   } catch (error) {
-    console.log(error);
+    console.log(axios.isAxiosError(error));
   }
 };
 

--- a/src/app/components/modals/DeleteCardModal.tsx
+++ b/src/app/components/modals/DeleteCardModal.tsx
@@ -1,0 +1,34 @@
+'use Client';
+
+import { useModal } from '@/context/ModalContext';
+import { deleteCard } from '../ToDoCardModal/api';
+import ModalFooterButtons from '../ModalFooterButtons';
+
+const DeleteCardModal = ({ cardId }: { cardId: number }) => {
+  const { closeModal } = useModal();
+
+  const handleDeleteCard = () => {
+    deleteCard(cardId);
+    closeModal();
+  };
+
+  const handleCancelButton = () => {
+    closeModal();
+  };
+
+  return (
+    <div className='relative flex h-[202px] w-[492px] items-center justify-center p-[4px]'>
+      <p className='text-[18px]'>카드가 삭제됩니다</p>
+      <div className='absolute bottom-0 right-0'>
+        <ModalFooterButtons
+          onAction={handleDeleteCard}
+          onCancel={handleCancelButton}
+          actionName='삭제'
+          isDisabled={true}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DeleteCardModal;

--- a/src/app/components/modals/DeleteColumnAlertModal.tsx
+++ b/src/app/components/modals/DeleteColumnAlertModal.tsx
@@ -5,9 +5,11 @@ import { deleteColumnByID } from '../ToDoCardModal/api';
 import ModalFooterButtons from '../ModalFooterButtons';
 
 const DeleteColumnAlertModal = ({ columnId }: { columnId: number }) => {
+  const { closeModal } = useModal();
+
   const handleDeleteColumn = (columnId: number) => {
     deleteColumnByID(columnId);
-    location.reload();
+    closeModal();
   };
 
   return (

--- a/src/app/components/modals/NewColumnModal.tsx
+++ b/src/app/components/modals/NewColumnModal.tsx
@@ -1,19 +1,38 @@
 'use client';
 
+import axios from 'axios';
+import instance from '@/app/api/axios';
 import { useState } from 'react';
-import { postNewColumnData } from '../ToDoCardModal/api';
 import ModalFooterButtons from '../ModalFooterButtons';
 import ModalInput from '../ModalInput';
 import { useModal } from '@/context/ModalContext';
 
-const NewColumnModal = ({ dashboardId }: { dashboardId: number }) => {
+const NewColumnModal = ({
+  dashboardId,
+  columnTitles,
+}: {
+  dashboardId: number;
+  columnTitles: string[];
+}) => {
   const [value, setValue] = useState<string>('');
+  const [errorMessage, setErrorMessage] = useState<string>('');
   const { closeModal } = useModal();
 
-  const handleOnCick = () => {
+  const handleOnCick = async (title: string, dashboardid: number) => {
     if (value) {
-      postNewColumnData(value, dashboardId);
-      closeModal();
+      const data = {
+        title: title,
+        dashboardId: dashboardid,
+      };
+      try {
+        if (columnTitles.includes(title)) {
+          throw new Error('중복된 칼럼 이름입니다.');
+        }
+        const res = await instance.post(`columns`, data);
+        closeModal();
+      } catch (error: any) {
+        setErrorMessage(error.message);
+      }
     }
   };
 
@@ -27,8 +46,16 @@ const NewColumnModal = ({ dashboardId }: { dashboardId: number }) => {
           placeFolder='새로운 프로젝트'
           value={value}
           setValue={setValue}
+          error={
+            <span className='mt-[8px] text-[14px] text-red-600'>
+              {errorMessage}
+            </span>
+          }
         />
-        <ModalFooterButtons value={value} onAction={handleOnCick} />
+        <ModalFooterButtons
+          value={value}
+          onAction={() => handleOnCick(value, dashboardId)}
+        />
       </div>
     </div>
   );

--- a/src/app/components/modals/NewColumnModal.tsx
+++ b/src/app/components/modals/NewColumnModal.tsx
@@ -4,21 +4,23 @@ import { useState } from 'react';
 import { postNewColumnData } from '../ToDoCardModal/api';
 import ModalFooterButtons from '../ModalFooterButtons';
 import ModalInput from '../ModalInput';
+import { useModal } from '@/context/ModalContext';
 
 const NewColumnModal = ({ dashboardId }: { dashboardId: number }) => {
   const [value, setValue] = useState<string>('');
+  const { closeModal } = useModal();
 
-  const handleSubmit = () => {
-    if (value && dashboardId) {
-      console.log(dashboardId, value);
+  const handleOnCick = () => {
+    if (value) {
       postNewColumnData(value, dashboardId);
+      closeModal();
     }
   };
 
   return (
     <div className='flex min-w-[492px] flex-col max-sm:min-w-[279px]'>
       <p className='text-[24px] font-bold max-sm:text-[20px]'>새 컬럼 생성</p>
-      <form className='flex flex-col gap-[28px]' onSubmit={handleSubmit}>
+      <div className='flex flex-col gap-[28px]'>
         <ModalInput
           labelName='이름'
           inputId='name'
@@ -26,8 +28,8 @@ const NewColumnModal = ({ dashboardId }: { dashboardId: number }) => {
           value={value}
           setValue={setValue}
         />
-        <ModalFooterButtons value={value} />
-      </form>
+        <ModalFooterButtons value={value} onAction={handleOnCick} />
+      </div>
     </div>
   );
 };

--- a/src/app/components/modals/ToDoCardModal.tsx
+++ b/src/app/components/modals/ToDoCardModal.tsx
@@ -53,7 +53,7 @@ export default function ToDoCardModal({
 
   return (
     <div className='flex w-[682px] flex-col gap-[24px] p-[4px] max-xl:w-[632px] max-sm:w-full max-sm:gap-[16px]'>
-      <CardHeader title={title} />
+      <CardHeader cardId={cardId} title={title} />
       {/* 컨텐츠 */}
       <div className='flex gap-[24px] max-sm:flex-col'>
         <div className='flex w-[450px] flex-col gap-[16px] max-xl:w-[420px] max-sm:order-2 max-sm:w-full'>

--- a/src/app/components/modals/ToDoCardModal.tsx
+++ b/src/app/components/modals/ToDoCardModal.tsx
@@ -5,28 +5,52 @@ import CardHeader from '../ToDoCardModal/CardHeader';
 import CardInfo from '../ToDoCardModal/CardInfo';
 import CommentInput from '../ToDoCardModal/CommentInput';
 import CardContents from '../ToDoCardModal/CardContents';
+import { useEffect, useState } from 'react';
+import { getCommentsByCardId } from '../ToDoCardModal/api';
 
-interface assignee {
+interface assigner {
   profileImageUrl?: string;
   nickname: string;
   id: number;
 }
 
 export default function ToDoCardModal({
+  dashboardId,
+  columnId,
   title,
   description,
   tags,
   dueDate,
-  assignee,
+  assigner,
   imageUrl,
+  cardId,
 }: {
+  dashboardId: number;
+  columnId: number;
   title: string;
   description: string;
   tags: string[];
   dueDate: string;
   imageUrl?: string;
-  assignee: assignee;
+  assigner: assigner;
+  cardId: number;
 }) {
+  const [comments, setComments] = useState<string[]>([]);
+
+  const fetchComments = async () => {
+    try {
+      const res = await getCommentsByCardId(cardId);
+      setComments(res.comments);
+    } catch (error: any) {
+      console.log(error);
+    }
+  };
+
+  // console.log(comments);
+  useEffect(() => {
+    fetchComments();
+  }, []);
+
   return (
     <div className='flex w-[682px] flex-col gap-[24px] p-[4px] max-xl:w-[632px] max-sm:w-full max-sm:gap-[16px]'>
       <CardHeader title={title} />
@@ -38,53 +62,15 @@ export default function ToDoCardModal({
             description={description}
             tags={tags}
           />
-          <CommentInput />
-          <CommentsList comments={commentsList.comments} />
+          <CommentInput
+            columnId={columnId}
+            dashboardId={dashboardId}
+            cardId={cardId}
+          />
+          {comments && <CommentsList comments={comments} />}
         </div>
-        <CardInfo assignee={assignee} dueDate={dueDate} />
+        <CardInfo assignee={assigner} dueDate={dueDate} />
       </div>
     </div>
   );
 }
-
-const commentsList = {
-  cursorId: 0,
-  comments: [
-    {
-      id: 0,
-      content: '이젠 this time is real',
-      createdAt: '2024-06-03T16:13:33.230Z',
-      updatedAt: '2024-06-03T16:13:33.230Z',
-      cardId: 0,
-      author: {
-        profileImageUrl: '/images/test/profile-test.jpeg',
-        nickname: '보아',
-        id: 0,
-      },
-    },
-    {
-      id: 1,
-      content: ' no one can deny',
-      createdAt: '2024-06-03T16:13:33.230Z',
-      updatedAt: '2024-06-03T16:13:33.230Z',
-      cardId: 0,
-      author: {
-        profileImageUrl: '',
-        nickname: '공중정원',
-        id: 0,
-      },
-    },
-    {
-      id: 2,
-      content: '세상 가운데 살아 숨 쉬는 곳',
-      createdAt: '2024-06-03T16:13:33.230Z',
-      updatedAt: '2024-06-03T16:13:33.230Z',
-      cardId: 0,
-      author: {
-        profileImageUrl: '',
-        nickname: '짱좋다',
-        id: 0,
-      },
-    },
-  ],
-};

--- a/src/app/components/modals/UpdateColumnModal.tsx
+++ b/src/app/components/modals/UpdateColumnModal.tsx
@@ -14,7 +14,7 @@ const UpdateColumnModal = ({
   columnId: number;
   title: string;
 }) => {
-  const { openModal } = useModal();
+  const { openModal, closeModal } = useModal();
   const [value, setValue] = useState<string>(title);
 
   const handleOpenModal = (content: React.ReactNode) => {
@@ -26,8 +26,10 @@ const UpdateColumnModal = ({
   };
 
   const handleUpdateColumn = (inputTitleData: string) => {
-    if (isValueChange(title, inputTitleData))
+    if (isValueChange(title, inputTitleData)) {
       putColumnByID(columnId, inputTitleData);
+      closeModal();
+    }
   };
 
   return (

--- a/src/app/components/modals/UpdateColumnModal.tsx
+++ b/src/app/components/modals/UpdateColumnModal.tsx
@@ -35,7 +35,7 @@ const UpdateColumnModal = ({
       <div className='text-[24px] font-bold text-custom_black-_333236'>
         컬럼 관리
       </div>
-      <form onSubmit={() => handleUpdateColumn(value)}>
+      <div>
         <ModalInput
           labelName='이름'
           inputId='title'
@@ -55,11 +55,12 @@ const UpdateColumnModal = ({
           </div>
           <ModalFooterButtons
             actionName={'변경'}
+            onAction={() => handleUpdateColumn(value)}
             value={value}
             isDisabled={isValueChange(title, value)}
           />
         </div>
-      </form>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## 구현내용
- 컬럼 수정/삭제/생성 관련 api 응답 못받는 오류 onSubmit이벤트 처리 없이 진행하여서 해결하였습니다
- column수정모달에 이름 중복 체크 기능 및 10개 이상 생성 못하는 에러처리도 진행하였습니다
- 칼럼 내 카드 데이터 매핑
- 카드 클릭시 ToDoModal에 해당 카드 데이터 매핑,
- 댓글 생성/수정/삭제 api 연결
- 카드 삭제하기 모달 기능까지 완료하였습니다.

## 이슈내용
- 카드 삭제하기에서 취소하면 페이지 기본화면으로 넘어가는데 다시 전 모달로 돌아가고싶지만 쉽지 않습니다.

## 다음 개발 예정 목록
- 기능은 무한 스크롤만 진행하면 될 것 같습니다.
- 이 후에는 오류 수정 및 리팩토링 진행하면 될 것 같습니다.