### PR TITLE
feat: 대시보드 수정 및 프로필 수정 시 다른 컴포넌트도 바뀌는 기능 추가 및 customAvatar 기본배경색상 규칙 설정

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -4,6 +4,7 @@ import React, { useState } from 'react';
 import SideBar from '../components/SideBar';
 import DashboardHeader from '../components/DashboardHeader';
 import DashboardHeaderInSettings from '../components/DashboardHeaderInSettings';
+import { UserDataProvider } from '@/context/UserDataContext';
 import { usePathname } from 'next/navigation';
 
 interface LayoutProps {
@@ -32,13 +33,15 @@ const DashboardLayout: React.FC<LayoutProps> = ({ children }) => {
   };
 
   return (
-    <div className='flex'>
-      <SideBar />
-      <div className='w-full'>
-        {renderHeader()}
-        <main>{children}</main>
+    <UserDataProvider>
+      <div className='flex'>
+        <SideBar />
+        <div className='w-full'>
+          {renderHeader()}
+          <main>{children}</main>
+        </div>
       </div>
-    </div>
+    </UserDataProvider>
   );
 };
 

--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React from 'react';
+import React, { useState } from 'react';
 import SideBar from '../components/SideBar';
 import DashboardHeader from '../components/DashboardHeader';
 import DashboardHeaderInSettings from '../components/DashboardHeaderInSettings';

--- a/src/app/components/CustomAvatar.tsx
+++ b/src/app/components/CustomAvatar.tsx
@@ -37,9 +37,9 @@ export default function CustomAvatar({
   const [backgroundColor, setBackgroundColor] = useState<string>('');
 
   const getRandomBackgroundColor = () => {
-    const randomIndex = Math.floor(Math.random() * colors.length);
-    const randomColor = colors[randomIndex];
-    return randomColor;
+    const firstLetter = nickName.charCodeAt(0);
+    const index = firstLetter % colors.length;
+    return colors[index];
   };
 
   useEffect(() => {

--- a/src/app/components/DashboardHeader.tsx
+++ b/src/app/components/DashboardHeader.tsx
@@ -5,6 +5,7 @@ import { LOGIN_TOKEN } from '@/app/api/apiStrings';
 import { CheckUserRes } from '@/app/api/apiTypes/userType';
 import instance from '@/app/api/axios';
 import { useRouter } from 'next/navigation';
+import CustomAvatar from './CustomAvatar';
 
 const DashboardHeader = ({ title }: { title: string }) => {
   const [user, setUser] = useState<CheckUserRes | null>(null);
@@ -48,12 +49,11 @@ const DashboardHeader = ({ title }: { title: string }) => {
         {title}
       </div>
       <div className='relative'>
-        <div className='flex items-center' onClick={handleNicknameClick}>
-          <div className='relative mx-3 h-[34px] w-[34px] cursor-pointer rounded-full border-2 border-white bg-blue-500 text-white'>
-            <p className='absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform'>
-              {user && user.nickname[0]}
-            </p>
-          </div>
+        <div
+          className='flex items-center gap-[8px]'
+          onClick={handleNicknameClick}
+        >
+          {user && <CustomAvatar nickName={user?.nickname} size='medium' />}
           <div className='mr-[80px] hidden w-[45px] cursor-pointer sm:block'>
             {user && user.nickname}
           </div>

--- a/src/app/components/DashboardHeader.tsx
+++ b/src/app/components/DashboardHeader.tsx
@@ -6,10 +6,16 @@ import { CheckUserRes } from '@/app/api/apiTypes/userType';
 import instance from '@/app/api/axios';
 import { useRouter } from 'next/navigation';
 import CustomAvatar from './CustomAvatar';
+import Image from 'next/image';
 
-const DashboardHeader = ({ title }: { title: string }) => {
+interface DashboardHeaderProps {
+  title: string;
+}
+
+const DashboardHeader = ({ title }: DashboardHeaderProps) => {
   const [user, setUser] = useState<CheckUserRes | null>(null);
   const [showDropdown, setShowDropdown] = useState(false);
+  const [userProfile, setUserProfile] = useState();
 
   const router = useRouter();
 
@@ -24,6 +30,7 @@ const DashboardHeader = ({ title }: { title: string }) => {
     setShowDropdown(false);
     router.push('/');
   };
+  console.log(user);
 
   useEffect(() => {
     const accessToken = localStorage.getItem(LOGIN_TOKEN);
@@ -53,7 +60,13 @@ const DashboardHeader = ({ title }: { title: string }) => {
           className='flex items-center gap-[8px]'
           onClick={handleNicknameClick}
         >
-          {user && <CustomAvatar nickName={user?.nickname} size='medium' />}
+          {user && (
+            <CustomAvatar
+              nickName={user?.nickname}
+              profileUrl={user.profileImageUrl}
+              size='medium'
+            />
+          )}
           <div className='mr-[80px] hidden w-[45px] cursor-pointer sm:block'>
             {user && user.nickname}
           </div>

--- a/src/app/components/DashboardHeader.tsx
+++ b/src/app/components/DashboardHeader.tsx
@@ -6,7 +6,7 @@ import { CheckUserRes } from '@/app/api/apiTypes/userType';
 import instance from '@/app/api/axios';
 import { useRouter } from 'next/navigation';
 import CustomAvatar from './CustomAvatar';
-import Image from 'next/image';
+import { useUserData } from '@/context/UserDataContext';
 
 interface DashboardHeaderProps {
   title: string;
@@ -15,7 +15,7 @@ interface DashboardHeaderProps {
 const DashboardHeader = ({ title }: DashboardHeaderProps) => {
   const [user, setUser] = useState<CheckUserRes | null>(null);
   const [showDropdown, setShowDropdown] = useState(false);
-  const [userProfile, setUserProfile] = useState();
+  const { userData, setUserData } = useUserData();
 
   const router = useRouter();
 
@@ -30,7 +30,6 @@ const DashboardHeader = ({ title }: DashboardHeaderProps) => {
     setShowDropdown(false);
     router.push('/');
   };
-  console.log(user);
 
   useEffect(() => {
     const accessToken = localStorage.getItem(LOGIN_TOKEN);
@@ -50,6 +49,10 @@ const DashboardHeader = ({ title }: DashboardHeaderProps) => {
     fetchUserData();
   }, []);
 
+  useEffect(() => {
+    console.log(userData);
+  }, [userData]);
+
   return (
     <div className='flex h-[60px] items-center justify-between border-b border-r border-t border-custom_gray-_d9d9d9 py-1'>
       <div className='ml-10 text-lg font-bold text-custom_black-_333236'>
@@ -60,15 +63,15 @@ const DashboardHeader = ({ title }: DashboardHeaderProps) => {
           className='flex items-center gap-[8px]'
           onClick={handleNicknameClick}
         >
-          {user && (
+          {userData && (
             <CustomAvatar
-              nickName={user?.nickname}
-              profileUrl={user.profileImageUrl}
+              nickName={userData.nickname}
+              profileUrl={userData.profileImageUrl}
               size='medium'
             />
           )}
           <div className='mr-[80px] hidden w-[45px] cursor-pointer sm:block'>
-            {user && user.nickname}
+            {userData && userData.nickname}
           </div>
         </div>
         {showDropdown && (

--- a/src/app/components/DashboardHeaderInSettings.tsx
+++ b/src/app/components/DashboardHeaderInSettings.tsx
@@ -11,6 +11,7 @@ import { useParams, useRouter } from 'next/navigation';
 import Link from 'next/link';
 import UserIcon from './UserIcon';
 import { CheckMembersRes } from '../api/apiTypes/membersType';
+import CustomAvatar from './CustomAvatar';
 
 interface DashboardHeaderInSettingsProps {
   link?: string;
@@ -147,7 +148,9 @@ const DashboardHeaderInSettings = ({
         <div className='ml-6 flex items-center sm:-space-x-2'>
           <div className='ml-[100px] flex items-center -space-x-2 sm:ml-0'>
             {members?.map((member: CheckMembersRes, index: number) =>
-              index < 4 ? <UserIcon key={member.id} member={member} /> : null,
+              index < 4 ? (
+                <CustomAvatar nickName={member.nickname} size='medium' />
+              ) : null,
             )}
             {members && members.length > 4 && (
               <div className='relative z-10'>
@@ -162,12 +165,11 @@ const DashboardHeaderInSettings = ({
         </div>
         <div className='h-10 border-r sm:pl-3'></div>
         <div className='relative'>
-          <div className='flex items-center' onClick={handleNicknameClick}>
-            <div className='relative mx-3 h-[34px] w-[34px] cursor-pointer rounded-full border-2 border-white bg-blue-500 text-white'>
-              <p className='absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2 transform'>
-                {user && user.nickname[0]}
-              </p>
-            </div>
+          <div
+            className='flex items-center gap-[8px]'
+            onClick={handleNicknameClick}
+          >
+            {user && <CustomAvatar nickName={user?.nickname} size='medium' />}
             <div className='mr-[80px] hidden w-[45px] cursor-pointer sm:block'>
               {user && user.nickname}
             </div>

--- a/src/app/components/DashboardHeaderInSettings.tsx
+++ b/src/app/components/DashboardHeaderInSettings.tsx
@@ -34,7 +34,7 @@ const DashboardHeaderInSettings = ({
   );
   const [members, setMembers] = useState<CheckMembersRes[]>();
   const [createdByMe, setCreatedByMe] = useState<boolean | null>(null);
-  const { dashboardsData, setDashboardsData } = useDashboardData();
+  const { dashboardsData } = useDashboardData();
   const { openModal } = useModal();
 
   const handleOpenModal = (content: React.ReactNode) => {

--- a/src/app/components/DashboardHeaderInSettings.tsx
+++ b/src/app/components/DashboardHeaderInSettings.tsx
@@ -149,7 +149,11 @@ const DashboardHeaderInSettings = ({
           <div className='ml-[100px] flex items-center -space-x-2 sm:ml-0'>
             {members?.map((member: CheckMembersRes, index: number) =>
               index < 4 ? (
-                <CustomAvatar nickName={member.nickname} size='medium' />
+                <CustomAvatar
+                  nickName={member.nickname}
+                  profileUrl={member.profileImageUrl}
+                  size='medium'
+                />
               ) : null,
             )}
             {members && members.length > 4 && (
@@ -169,7 +173,13 @@ const DashboardHeaderInSettings = ({
             className='flex items-center gap-[8px]'
             onClick={handleNicknameClick}
           >
-            {user && <CustomAvatar nickName={user?.nickname} size='medium' />}
+            {user && (
+              <CustomAvatar
+                nickName={user?.nickname}
+                profileUrl={user.profileImageUrl}
+                size='medium'
+              />
+            )}
             <div className='mr-[80px] hidden w-[45px] cursor-pointer sm:block'>
               {user && user.nickname}
             </div>

--- a/src/app/components/DashboardHeaderInSettings.tsx
+++ b/src/app/components/DashboardHeaderInSettings.tsx
@@ -12,6 +12,7 @@ import Link from 'next/link';
 import UserIcon from './UserIcon';
 import { CheckMembersRes } from '../api/apiTypes/membersType';
 import CustomAvatar from './CustomAvatar';
+import { useDashboardData } from '@/context/DashboardDataContext';
 
 interface DashboardHeaderInSettingsProps {
   link?: string;
@@ -33,7 +34,7 @@ const DashboardHeaderInSettings = ({
   );
   const [members, setMembers] = useState<CheckMembersRes[]>();
   const [createdByMe, setCreatedByMe] = useState<boolean | null>(null);
-
+  const { dashboardsData, setDashboardsData } = useDashboardData();
   const { openModal } = useModal();
 
   const handleOpenModal = (content: React.ReactNode) => {
@@ -66,17 +67,19 @@ const DashboardHeaderInSettings = ({
         console.error(error);
       }
     };
-
     const fetchDashboardData = async () => {
       try {
         const res = await instance.get(`dashboards/${params.dashboardid}`);
-        setTitle(res.data.title);
+        dashboardsData.map((data) => {
+          if (data.id == dashboardId) {
+            setTitle(data.title);
+          }
+        });
         setCreatedByMe(res.data.createdByMe);
       } catch (error) {
         console.error(error);
       }
     };
-
     const fetchDashboardMemberData = async () => {
       try {
         const res = await instance.get('members', {
@@ -95,7 +98,7 @@ const DashboardHeaderInSettings = ({
     fetchUserData();
     fetchDashboardData();
     fetchDashboardMemberData();
-  }, [params.dashboardid]);
+  }, [params.dashboardid, dashboardsData]);
 
   return (
     <nav className='flex h-[60px] items-center justify-between border-b'>

--- a/src/app/components/InvitationList.tsx
+++ b/src/app/components/InvitationList.tsx
@@ -75,7 +75,7 @@ export default function InvitationList({
       setTotalCount(res.data.totalCount);
     };
     fetchInvitationListData();
-  }, [invitationList]);
+  }, [currentPage]);
 
   return (
     <div className='m-5 w-[620px] rounded-lg bg-custom_white max-xl:w-auto max-xl:max-w-[620px] max-sm:mx-3'>

--- a/src/app/components/MemberList.tsx
+++ b/src/app/components/MemberList.tsx
@@ -68,8 +68,6 @@ export default function MemberList({ dashboardid }: { dashboardid: number }) {
     fetchMembersData();
   }, []);
 
-  console.log(memberList);
-
   return (
     <div className='m-5 w-[620px] rounded-lg bg-custom_white max-xl:w-auto max-xl:max-w-[620px] max-sm:mx-3'>
       <EditMenuTitle

--- a/src/app/components/ProfileSetting.tsx
+++ b/src/app/components/ProfileSetting.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 import Image from 'next/image';
 import { useModal } from '@/context/ModalContext';
 import SettingChangedModal from './modals/SettingChangedModal';
+import { useUserData } from '@/context/UserDataContext';
 import instance from '../api/axios';
 import axios from 'axios';
 
@@ -16,7 +17,8 @@ interface ProfileSettingValues {
 }
 
 export default function ProfileSetting() {
-  const [uploadedImage, setUploadedImage] = useState<string | null>(null);
+  const [uploadedImage, setUploadedImage] = useState<string | undefined>();
+  const { userData, setUserData } = useUserData();
 
   const {
     register,
@@ -48,7 +50,7 @@ export default function ProfileSetting() {
     const { files } = e.target;
 
     if (!files || files.length === 0) {
-      setUploadedImage(null);
+      setUploadedImage(undefined);
       return;
     }
 
@@ -70,9 +72,12 @@ export default function ProfileSetting() {
     };
     try {
       const response = await instance.put('users/me', formData);
-      handleOpenModal(
-        <SettingChangedModal> 프로필이 변경되었습니다. </SettingChangedModal>,
-      );
+      if (response.status >= 200 && response.status < 300) {
+        setUserData(formData);
+        handleOpenModal(
+          <SettingChangedModal> 프로필이 변경되었습니다. </SettingChangedModal>,
+        );
+      }
     } catch (e: unknown) {
       if (axios.isAxiosError(e)) {
         const error = e.response?.data.message; // 에러발생시 메시지 저장

--- a/src/app/components/UpdateDashboardName.tsx
+++ b/src/app/components/UpdateDashboardName.tsx
@@ -2,14 +2,15 @@ import Image from 'next/image';
 import { useEffect, useState } from 'react';
 import instance from '../api/axios';
 import { useParams } from 'next/navigation';
+import { useDashboardData } from '@/context/DashboardDataContext';
 
 const UpdateDashboardName = ({ dashboardid }: { dashboardid: number }) => {
   const params = useParams();
+  const { dashboardsData, setDashboardsData } = useDashboardData();
 
   const [selectedColor, setSelectedColor] = useState<string>('#7ac555');
   const [dashboardName, setDashboardName] = useState<string>('');
   const [title, setTitle] = useState<string | null>(null);
-
   const colors = [
     { name: '#7ac555', bgColor: 'bg-custom_green-_7ac555' },
     { name: '#760dde', bgColor: 'bg-custom_purple' },
@@ -41,6 +42,13 @@ const UpdateDashboardName = ({ dashboardid }: { dashboardid: number }) => {
       console.log('POST 요청 성공:', response.data);
       setTitle(response.data.title);
       setDashboardName('');
+      setDashboardsData((prevDashboardsData) =>
+        prevDashboardsData.map((dashboard) =>
+          parseInt(dashboard.id) == dashboardid
+            ? { ...dashboard, title: response.data.title }
+            : dashboard,
+        ),
+      );
     } catch (e) {
       alert('대시보드 수정에 실패했습니다.');
     }
@@ -58,7 +66,7 @@ const UpdateDashboardName = ({ dashboardid }: { dashboardid: number }) => {
     };
 
     fetchDashboardData();
-  }, [params.dashboardid]);
+  }, [params.dashboardid, dashboardsData]);
 
   return (
     <div className='m-5 w-[620px] rounded-lg bg-custom_white px-[28px] py-8 max-xl:w-auto max-xl:max-w-[620px] max-sm:mx-3'>

--- a/src/app/components/UpdateDashboardName.tsx
+++ b/src/app/components/UpdateDashboardName.tsx
@@ -45,7 +45,11 @@ const UpdateDashboardName = ({ dashboardid }: { dashboardid: number }) => {
       setDashboardsData((prevDashboardsData) =>
         prevDashboardsData.map((dashboard) =>
           parseInt(dashboard.id) == dashboardid
-            ? { ...dashboard, title: response.data.title }
+            ? {
+                ...dashboard,
+                title: response.data.title,
+                color: response.data.color,
+              }
             : dashboard,
         ),
       );

--- a/src/context/UserDataContext.tsx
+++ b/src/context/UserDataContext.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import instance from '@/app/api/axios';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  ReactNode,
+  useEffect,
+} from 'react';
+
+interface UserDataContextProps {
+  nickname: string;
+  profileImageUrl?: string | undefined;
+}
+
+interface UserDataProviderProps {
+  children: ReactNode;
+}
+
+interface UserDataContextType {
+  userData: UserDataContextProps | undefined;
+  setUserData: React.Dispatch<
+    React.SetStateAction<UserDataContextProps | undefined>
+  >;
+}
+
+// 대시보드 데이터 컨텍스트 생성
+const UserDataContext = createContext<UserDataContextType | undefined>(
+  undefined,
+);
+
+// 대시보드 데이터 제공자 컴포넌트
+export const UserDataProvider = ({ children }: UserDataProviderProps) => {
+  const [userData, setUserData] = useState<UserDataContextProps>();
+
+  useEffect(() => {
+    const fetchUserData = async () => {
+      try {
+        const res = await instance.get('users/me');
+        setUserData(res.data);
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchUserData();
+  }, []);
+
+  return (
+    <UserDataContext.Provider value={{ userData, setUserData }}>
+      {children}
+    </UserDataContext.Provider>
+  );
+};
+
+// 대시보드 데이터를 사용하기 위한 Hook
+export const useUserData = () => {
+  const context = useContext(UserDataContext);
+  if (context === undefined) {
+    throw new Error('유저데이터 사용불가능!');
+  }
+  return context;
+};


### PR DESCRIPTION
dashboard페이지의 layout.tsx 에만 유저데이터 컨텍스트를 가져와서 구현했습니다.


<img width="875" alt="스크린샷 2024-06-12 오후 10 44 51" src="https://github.com/codeit-project-9/taskify/assets/159985297/bcb56a6b-b23c-4aef-b8e1-8a7ab4563919"></br>
대시보드 수정 반영


<img width="899" alt="스크린샷 2024-06-12 오후 10 42 35" src="https://github.com/codeit-project-9/taskify/assets/159985297/faceb83e-8108-4cb8-8b37-44278ed2168d">
<img width="904" alt="스크린샷 2024-06-12 오후 10 43 19" src="https://github.com/codeit-project-9/taskify/assets/159985297/c1289ca4-5a65-4091-b99a-90dc95217e4b"></br>
닉네임 변경 반영