### PR TITLE
feat: 초대받은 대시보드 리스트 모바일 버전 무한스크롤 구현 및 데스크탑 부분, 모바일 부분을 CSS 가 아닌 로직으로 변경

### DIFF
--- a/src/app/(dashboard)/mydashboard/page.tsx
+++ b/src/app/(dashboard)/mydashboard/page.tsx
@@ -1,14 +1,34 @@
+'use client';
+
+import { useEffect, useState } from 'react';
 import DashboardCard from '@/app/components/DashboardCard';
-import InvitedDashboardList from '@/app/components/InvitedDashboarList';
 import InvitedDashboardListMobile from '@/app/components/InvitedDashboardListMobile';
+import InvitedDashboardList from '@/app/components/InvitedDashboarList';
 
 const MyDashboard = () => {
+  const [isMobile, setIsMobile] = useState(false);
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const handleResize = () => {
+        setIsMobile(window.innerWidth <= 640);
+      };
+
+      handleResize();
+
+      window.addEventListener('resize', handleResize);
+
+      return () => {
+        window.removeEventListener('resize', handleResize);
+      };
+    }
+  }, []);
+
   return (
     <div className='flex'>
       <div className='w-full bg-custom_gray-_fafafa pb-5 pr-6'>
         <DashboardCard />
-        <InvitedDashboardList />
-        <InvitedDashboardListMobile />
+        {isMobile ? <InvitedDashboardListMobile /> : <InvitedDashboardList />}
       </div>
     </div>
   );

--- a/src/app/components/DashboardHeaderInSettings.tsx
+++ b/src/app/components/DashboardHeaderInSettings.tsx
@@ -100,7 +100,6 @@ const DashboardHeaderInSettings = ({
     <nav className='flex h-[60px] items-center justify-between border-b'>
       <div className='hidden items-center sm:flex'>
         <span className='ml-10 text-lg font-bold'>{title}</span>
-        {/* TODO: 내가 만든 부분에서만 crown 설정 */}
         {createdByMe === true ? (
           <span className='ml-2 text-yellow-500'>
             <Image
@@ -115,7 +114,7 @@ const DashboardHeaderInSettings = ({
       <div className='flex items-center space-x-2'>
         <div className='mr-10 flex space-x-4 text-[14px] text-custom_gray-_787486 sm:text-[16px]'>
           {/* 대시보드 설정페이지에서 비활성화 */}
-          {link && (
+          {createdByMe === true && link && (
             <Link
               href={link}
               className='flex w-[50px] items-center justify-center rounded-md border bg-white px-2 py-1 sm:w-[88px]'
@@ -130,19 +129,21 @@ const DashboardHeaderInSettings = ({
               <p>관리</p>
             </Link>
           )}
-          <button
-            className='flex w-[70px] items-center justify-center rounded-md border bg-white px-2 py-1 sm:w-[116px]'
-            onClick={() => handleOpenModal(<InvitationModal />)}
-          >
-            <Image
-              className='mr-2 hidden sm:block'
-              src='/images/addTaskButton.svg'
-              alt='add'
-              width={20}
-              height={20}
-            />
-            <p>초대하기</p>
-          </button>
+          {createdByMe && (
+            <button
+              className='flex w-[70px] items-center justify-center rounded-md border bg-white px-2 py-1 sm:w-[116px]'
+              onClick={() => handleOpenModal(<InvitationModal />)}
+            >
+              <Image
+                className='mr-2 hidden sm:block'
+                src='/images/addTaskButton.svg'
+                alt='add'
+                width={20}
+                height={20}
+              />
+              <p>초대하기</p>
+            </button>
+          )}
         </div>
         <div className='ml-6 flex items-center sm:-space-x-2'>
           <div className='ml-[100px] flex items-center -space-x-2 sm:ml-0'>

--- a/src/app/components/InvitationList.tsx
+++ b/src/app/components/InvitationList.tsx
@@ -74,6 +74,7 @@ export default function InvitationList({
       setInvitationList(res.data.invitations);
       setTotalCount(res.data.totalCount);
     };
+
     fetchInvitationListData();
   }, [invitationList]);
 

--- a/src/app/components/InvitedDashboarList.tsx
+++ b/src/app/components/InvitedDashboarList.tsx
@@ -27,6 +27,7 @@ const InvitedDashboardList = () => {
         },
       });
       const newInvitations = res.data.invitations;
+
       setInvitations((prev) => {
         const mergedInvitations = [...prev, ...newInvitations];
         const uniqueInvitations = mergedInvitations.filter(
@@ -35,6 +36,7 @@ const InvitedDashboardList = () => {
         );
         return uniqueInvitations;
       });
+
       setFilteredInvitations((prev) => {
         const mergedFilteredInvitations = [...prev, ...newInvitations];
         const uniqueFilteredInvitations = mergedFilteredInvitations.filter(
@@ -160,7 +162,7 @@ const InvitedDashboardList = () => {
               value={searchTerm}
               onChange={handleSearchChange}
             />
-            <img
+            <Image
               className='absolute top-[15px] ml-4'
               src='/images/search.svg'
               alt='search'

--- a/src/app/components/InvitedDashboardListMobile.tsx
+++ b/src/app/components/InvitedDashboardListMobile.tsx
@@ -137,7 +137,7 @@ const InvitedDashboardListMobile = () => {
   );
 
   return (
-    <div className='ml-6 mt-6 h-[800px] overflow-scroll rounded-lg bg-custom_white px-7 py-8 sm:hidden'>
+    <div className='ml-6 mt-6 h-[800px] overflow-scroll rounded-lg bg-custom_white px-7 py-8'>
       <div className='text-2xl font-bold text-custom_black-_333236'>
         초대받은 대시보드
       </div>

--- a/src/app/components/InvitedDashboardListMobile.tsx
+++ b/src/app/components/InvitedDashboardListMobile.tsx
@@ -1,52 +1,208 @@
+'use client';
+
 import Image from 'next/image';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { CheckInvitationsRes } from '../api/apiTypes/invitationsType';
+import instance from '../api/axios';
 
 const InvitedDashboardListMobile = () => {
-  const data = [
-    { id: 1, name: '프로덕트 디자인', inviter: '손동희' },
-    { id: 2, name: '새로운 기획 문서', inviter: '안귀영' },
-    { id: 3, name: '유닛 A', inviter: '장혁' },
-  ];
+  const [invitations, setInvitations] = useState<
+    CheckInvitationsRes['invitations']
+  >([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [filteredInvitations, setFilteredInvitations] = useState<
+    CheckInvitationsRes['invitations']
+  >([]);
+  const [cursorId, setCursorId] = useState<number | null>(null);
+  const [loading, setLoading] = useState(false);
+  const size = 6;
+
+  const intersectionTargetRef = useRef<HTMLDivElement | null>(null);
+
+  const fetchInvitations = async (cursorId: number | null) => {
+    setLoading(true);
+    try {
+      const res = await instance.get('invitations', {
+        params: { cursorId, size },
+      });
+      const newInvitations = res.data.invitations;
+      setInvitations((prev) => {
+        const mergedInvitations = [...prev, ...newInvitations];
+        const uniqueInvitations = mergedInvitations.filter(
+          (invitation, index, self) =>
+            index === self.findIndex((i) => i.id === invitation.id),
+        );
+        return uniqueInvitations;
+      });
+
+      setFilteredInvitations((prev) => {
+        const mergedFilteredInvitations = [...prev, ...newInvitations];
+        const uniqueFilteredInvitations = mergedFilteredInvitations.filter(
+          (invitation, index, self) =>
+            index === self.findIndex((i) => i.id === invitation.id),
+        );
+        return uniqueFilteredInvitations;
+      });
+
+      if (newInvitations.length > 0) {
+        setCursorId(newInvitations[newInvitations.length - 1].id);
+      }
+    } catch (error) {
+      console.error('Error fetching invitations:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleIntersection = useCallback(
+    (entries: IntersectionObserverEntry[]) => {
+      const target = entries[0];
+      if (target.isIntersecting && !loading) {
+        fetchInvitations(cursorId);
+      }
+    },
+    [cursorId, loading],
+  );
+
+  useEffect(() => {
+    const observer = new IntersectionObserver(handleIntersection, {
+      root: null,
+      rootMargin: '0px',
+      threshold: 1.0,
+    });
+
+    const target = intersectionTargetRef.current;
+    if (target) {
+      observer.observe(target);
+    }
+
+    return () => {
+      if (target) {
+        observer.unobserve(target);
+      }
+    };
+  }, [handleIntersection]);
+
+  useEffect(() => {
+    fetchInvitations(null);
+  }, []);
+
+  const debounce = (func: Function, delay: number) => {
+    let timer: ReturnType<typeof setTimeout>;
+    return (...args: any[]) => {
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        func(...args);
+      }, delay);
+    };
+  };
+
+  const handleInvitationResponse = async (
+    invitationId: number,
+    inviteAccepted: boolean,
+  ) => {
+    try {
+      await instance.put(`invitations/${invitationId}`, { inviteAccepted });
+      setInvitations((prev) =>
+        prev.filter((invitation) => invitation.id !== invitationId),
+      );
+      setFilteredInvitations((prev) =>
+        prev.filter((invitation) => invitation.id !== invitationId),
+      );
+    } catch (error) {
+      console.error('Error responding to invitation:', error);
+    }
+  };
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value);
+    debouncedFilterInvitations(e.target.value);
+  };
+
+  const debouncedFilterInvitations = useCallback(
+    debounce((term: string) => {
+      if (term === '') {
+        setFilteredInvitations(invitations);
+      } else {
+        setFilteredInvitations(
+          invitations.filter((invitation) =>
+            invitation.dashboard.title
+              .toLowerCase()
+              .includes(term.toLowerCase()),
+          ),
+        );
+      }
+    }, 500),
+    [invitations],
+  );
 
   return (
-    <div className='ml-6 mt-6 rounded-lg bg-custom_white px-7 py-8 sm:hidden'>
+    <div className='ml-6 mt-6 h-[800px] overflow-scroll rounded-lg bg-custom_white px-7 py-8 sm:hidden'>
       <div className='text-2xl font-bold text-custom_black-_333236'>
         초대받은 대시보드
       </div>
-      <div className='relative mt-5'>
-        <input
-          className='w-full rounded-md border border-custom_gray-_d9d9d9 p-3 indent-8 text-[16px]'
-          placeholder='검색'
-        />
-        <Image
-          className='absolute top-[15px] ml-4'
-          src='/images/search.svg'
-          alt='search'
-          width={15}
-          height={15}
-        />
-      </div>
-      <div>
-        {data.map((item) => (
-          <div key={item.id} className='mt-5'>
-            <div className='flex gap-x-7 text-[14px]'>
-              <div className='text-custom_gray-_9fa6b2'>이름</div>
-              <div>{item.name}</div>
-            </div>
-            <div className='flex gap-x-4 text-[14px]'>
-              <div className='text-custom_gray-_9fa6b2'>초대자</div>
-              <div className=''>{item.inviter}</div>
-            </div>
-            <div className='mt-5 flex gap-x-[10px]'>
-              <button className='flex-1 rounded bg-custom_violet-_5534da px-7 py-2 text-white'>
-                수락
-              </button>
-              <button className='flex-1 rounded border border-custom_gray-_d9d9d9 bg-white px-7 py-2 text-custom_violet-_5534da'>
-                거절
-              </button>
-            </div>
+      {invitations.length === 0 ? (
+        <div className='flex flex-col items-center justify-center'>
+          <Image
+            src='/images/no-invitation.svg'
+            width={100}
+            height={100}
+            alt='no invitation'
+          />
+          <div>아직 초대받은 대시보드가 없어요.</div>
+        </div>
+      ) : (
+        <>
+          <div className='relative mt-5'>
+            <input
+              className='w-full rounded-md border border-custom_gray-_d9d9d9 p-3 indent-8 text-[16px]'
+              placeholder='검색'
+              value={searchTerm}
+              onChange={handleSearchChange}
+            />
+            <Image
+              className='absolute top-[15px] ml-4'
+              src='/images/search.svg'
+              alt='search'
+              width={15}
+              height={15}
+            />
           </div>
-        ))}
-      </div>
+          <div>
+            {filteredInvitations.map((invitation) => (
+              <div key={invitation.id} className='mt-5'>
+                <div className='flex gap-x-7 text-[14px]'>
+                  <div className='text-custom_gray-_9fa6b2'>이름</div>
+                  <div>{invitation.dashboard.title}</div>
+                </div>
+                <div className='flex gap-x-4 text-[14px]'>
+                  <div className='text-custom_gray-_9fa6b2'>초대자</div>
+                  <div className=''>{invitation.inviter.nickname}</div>
+                </div>
+                <div className='mt-5 flex gap-x-[10px]'>
+                  <button
+                    className='flex-1 rounded bg-custom_violet-_5534da px-7 py-2 text-white'
+                    onClick={() =>
+                      handleInvitationResponse(invitation.id, true)
+                    }
+                  >
+                    수락
+                  </button>
+                  <button
+                    className='flex-1 rounded border border-custom_gray-_d9d9d9 bg-white px-7 py-2 text-custom_violet-_5534da'
+                    onClick={() =>
+                      handleInvitationResponse(invitation.id, false)
+                    }
+                  >
+                    거절
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+      <div ref={intersectionTargetRef} style={{ height: '1px' }}></div>
     </div>
   );
 };

--- a/src/app/components/MemberList.tsx
+++ b/src/app/components/MemberList.tsx
@@ -68,8 +68,6 @@ export default function MemberList({ dashboardid }: { dashboardid: number }) {
     fetchMembersData();
   }, []);
 
-  console.log(memberList);
-
   return (
     <div className='m-5 w-[620px] rounded-lg bg-custom_white max-xl:w-auto max-xl:max-w-[620px] max-sm:mx-3'>
       <EditMenuTitle

--- a/src/app/components/modals/InvitationModal.tsx
+++ b/src/app/components/modals/InvitationModal.tsx
@@ -2,6 +2,7 @@
 
 import instance from '@/app/api/axios';
 import { useModal } from '@/context/ModalContext';
+import axios, { AxiosError } from 'axios';
 import { useParams } from 'next/navigation';
 import { ChangeEvent, useState } from 'react';
 
@@ -30,7 +31,11 @@ const InvitationModal: React.FC = () => {
 
       closeModal();
     } catch (error) {
-      console.error(error);
+      if (axios.isAxiosError(error)) {
+        alert(error.response?.data.message);
+      } else {
+        console.log('알 수 없는 에러가 발생했습니다.', error);
+      }
     }
   };
 


### PR DESCRIPTION
1. 초대받은 대시보드 리스트 모바일 버전을 무한스크롤로 구현하였습니다.
2. 데스크탑, 모바일 분기를 CSS 가 아닌 로직으로 구현하였습니다.
3. 내가 만든 대시보드가 아니라면 헤더 부분에 '관리', '초대하기' 버튼이 보이지 않도록 수정하였습니다.