### PR TITLE
feat: 초대 수락 시 대시보드 페이지 이동 및 초대내역 컨텍스트 생성 및 중복 이메일 초대방지 기능 추가

### DIFF
--- a/src/app/(dashboard)/dashboard/[dashboardid]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/[dashboardid]/edit/page.tsx
@@ -29,10 +29,12 @@ export default function dashboardEditPage({ params }: PageProps) {
   const onClick = async () => {
     try {
       const response = await instance.delete(`/dashboards/${dashboardid}`);
-      handleOpenModal(
-        <SettingChangedModal>대시보드가 삭제되었습니다.</SettingChangedModal>,
-      );
-      router.push('/mydashboard');
+      if (response.status >= 200 && response.status < 300) {
+        handleOpenModal(
+          <SettingChangedModal>대시보드가 삭제되었습니다.</SettingChangedModal>,
+        );
+        router.push('/mydashboard');
+      }
     } catch (e: unknown) {
       <SettingChangedModal>
         대시보드가 삭제에 실패하였습니다.

--- a/src/app/components/DashboardHeader.tsx
+++ b/src/app/components/DashboardHeader.tsx
@@ -66,7 +66,7 @@ const DashboardHeader = ({ title }: DashboardHeaderProps) => {
               size='medium'
             />
           )}
-          <div className='mr-[80px] hidden w-[45px] cursor-pointer sm:block'>
+          <div className='mr-[80px] hidden w-[60px] cursor-pointer truncate sm:block'>
             {userData && userData.nickname}
           </div>
         </div>

--- a/src/app/components/DashboardHeader.tsx
+++ b/src/app/components/DashboardHeader.tsx
@@ -49,10 +49,6 @@ const DashboardHeader = ({ title }: DashboardHeaderProps) => {
     fetchUserData();
   }, []);
 
-  useEffect(() => {
-    console.log(userData);
-  }, [userData]);
-
   return (
     <div className='flex h-[60px] items-center justify-between border-b border-r border-t border-custom_gray-_d9d9d9 py-1'>
       <div className='ml-10 text-lg font-bold text-custom_black-_333236'>

--- a/src/app/components/DashboardHeaderInSettings.tsx
+++ b/src/app/components/DashboardHeaderInSettings.tsx
@@ -184,7 +184,7 @@ const DashboardHeaderInSettings = ({
                 size='medium'
               />
             )}
-            <div className='mr-[80px] hidden w-[45px] cursor-pointer sm:block'>
+            <div className='mr-[80px] hidden w-[60px] cursor-pointer truncate sm:block'>
               {user && user.nickname}
             </div>
           </div>

--- a/src/app/components/DashboardHeaderInSettings.tsx
+++ b/src/app/components/DashboardHeaderInSettings.tsx
@@ -71,7 +71,7 @@ const DashboardHeaderInSettings = ({
       try {
         const res = await instance.get(`dashboards/${params.dashboardid}`);
         dashboardsData.map((data) => {
-          if (data.id == dashboardId) {
+          if (data.id == params.dashboardid) {
             setTitle(data.title);
           }
         });

--- a/src/app/components/DashboardList.tsx
+++ b/src/app/components/DashboardList.tsx
@@ -91,7 +91,7 @@ export default function DashboardList() {
             <div
               className={`h-2 w-2 rounded-full ${ColorPalette[todo.color]}`}
             />
-            <div className='max-sm:hidden'>{todo.title}</div>
+            <div className='w-[80px] truncate max-sm:hidden'>{todo.title}</div>
             {todo.createdByMe && (
               <div className='relative h-3.5 w-5 max-sm:hidden'>
                 <Image

--- a/src/app/components/InvitationList.tsx
+++ b/src/app/components/InvitationList.tsx
@@ -10,6 +10,7 @@ import { useModal } from '@/context/ModalContext';
 import SettingChangedModal from './modals/SettingChangedModal';
 import axios from 'axios';
 import InvitationModal from './modals/InvitationModal';
+import { useInvitationData } from '@/context/InvitationDataContext';
 
 export default function InvitationList({
   dashboardid,
@@ -18,14 +19,12 @@ export default function InvitationList({
 }) {
   const { openModal } = useModal();
   const [currentPage, setCurrentPage] = useState(1);
-  const [invitationList, setInvitationList] = useState<LoadInvitationsRes[]>(
-    [],
-  );
   const [totalCount, setTotalCount] = useState<number>(10);
   const totalPage = Math.ceil(totalCount / 5) || 1;
 
   /** 대시보드 조회 파라미터 */
   const queryParams = { page: currentPage, size: 5 };
+  const { invitationData, setInvitationData } = useInvitationData(); // 초대내역 컨텍스트
 
   const handleNextPage = () => {
     if (currentPage * 5 < mockData.length) {
@@ -52,8 +51,9 @@ export default function InvitationList({
         handleOpenModal(
           <SettingChangedModal>초대가 취소되었습니다.</SettingChangedModal>,
         );
-        setInvitationList(
-          (prev) => prev?.filter((invitation) => invitation.id !== id) || null,
+        setInvitationData(
+          (prev) =>
+            prev?.filter((invitation) => invitation.id !== id) || undefined,
         );
       }
     } catch (e: unknown) {
@@ -65,13 +65,13 @@ export default function InvitationList({
     }
   };
 
-  /** 멤버리스트 조회 */
+  /** 초대내역 조회 */
   useEffect(() => {
     const fetchInvitationListData = async () => {
       const res = await instance.get(`dashboards/${dashboardid}/invitations`, {
         params: queryParams,
       });
-      setInvitationList(res.data.invitations);
+      setInvitationData(res.data.invitations);
       setTotalCount(res.data.totalCount);
     };
 
@@ -104,9 +104,9 @@ export default function InvitationList({
         </button>
       </div>
       <div className='flex flex-col px-[28px] pb-[28px]'>
-        {invitationList.length > 0 ? (
+        {invitationData.length > 0 ? (
           <div>
-            {invitationList.map((email) => {
+            {invitationData.map((email) => {
               return (
                 <div
                   key={email.id}

--- a/src/app/components/modals/NewDashboardModal.tsx
+++ b/src/app/components/modals/NewDashboardModal.tsx
@@ -45,13 +45,21 @@ const NewDashboardModal: React.FC = () => {
     try {
       const response = await instance.post('dashboards', requestData);
       if (response.status >= 200 && response.status < 300) {
-        console.log('POST 요청 성공:', response.data);
-        setDashboardsData((prev) => {
-          const newData = [...prev];
-          newData.pop();
-          newData.unshift(response.data);
-          return newData;
-        });
+        if (dashboardsData.length >= 10) {
+          console.log('POST 요청 성공:', response.data);
+          setDashboardsData((prev) => {
+            const newData = [...prev];
+            newData.pop();
+            newData.unshift(response.data);
+            return newData;
+          });
+        } else {
+          setDashboardsData((prev) => {
+            const newData = [...prev];
+            newData.unshift(response.data);
+            return newData;
+          });
+        }
         router.push(`/dashboard/${response.data.id}`);
       }
     } catch (e) {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import './globals.css';
 import { ModalProvider } from '@/context/ModalContext';
 import { DashboardDataProvider } from '@/context/DashboardDataContext';
+import { InvitationDataProvider } from '@/context/InvitationDataContext';
 import CommonModal from './components/modals/CommonModal';
 
 export default function RootLayout({
@@ -12,10 +13,12 @@ export default function RootLayout({
     <html lang='ko'>
       <body>
         <ModalProvider>
-          <DashboardDataProvider>
-            {children}
-            <CommonModal />
-          </DashboardDataProvider>
+          <InvitationDataProvider>
+            <DashboardDataProvider>
+              {children}
+              <CommonModal />
+            </DashboardDataProvider>
+          </InvitationDataProvider>
         </ModalProvider>
       </body>
     </html>

--- a/src/context/InvitationDataContext.tsx
+++ b/src/context/InvitationDataContext.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+interface InvitationDataContextProps {
+  id: number;
+  inviter: {
+    nickname: string;
+    email: string;
+    id: number;
+  };
+  teamId: string;
+  dashboard: {
+    title: string;
+    id: number;
+  };
+  invitee: {
+    nickname: string;
+    email: string;
+    id: number;
+  };
+  inviteAccepted: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface InvitationDataProviderProps {
+  children: ReactNode;
+}
+
+interface InvitationiDataContextType {
+  invitationData: InvitationDataContextProps[];
+  setInvitationData: React.Dispatch<
+    React.SetStateAction<InvitationDataContextProps[]>
+  >;
+}
+
+// 초대내역 데이터 컨텍스트 생성
+const InvitationDataContext = createContext<
+  InvitationiDataContextType | undefined
+>(undefined);
+
+// 초대내역 데이터 제공자 컴포넌트
+export const InvitationDataProvider = ({
+  children,
+}: InvitationDataProviderProps) => {
+  const [invitationData, setInvitationData] = useState<
+    InvitationDataContextProps[]
+  >([]);
+
+  return (
+    <InvitationDataContext.Provider
+      value={{
+        invitationData,
+        setInvitationData,
+      }}
+    >
+      {children}
+    </InvitationDataContext.Provider>
+  );
+};
+
+// 초대내역 데이터를 사용하기 위한 Hook
+export const useInvitationData = () => {
+  const context = useContext(InvitationDataContext);
+  if (context === undefined) {
+    throw new Error('초대내역 데이터 사용불가능!');
+  }
+  return context;
+};

--- a/src/context/UserDataContext.tsx
+++ b/src/context/UserDataContext.tsx
@@ -25,12 +25,12 @@ interface UserDataContextType {
   >;
 }
 
-// 대시보드 데이터 컨텍스트 생성
+// 유저데이터 컨텍스트 생성
 const UserDataContext = createContext<UserDataContextType | undefined>(
   undefined,
 );
 
-// 대시보드 데이터 제공자 컴포넌트
+// 유저 데이터 제공자 컴포넌트
 export const UserDataProvider = ({ children }: UserDataProviderProps) => {
   const [userData, setUserData] = useState<UserDataContextProps>();
 
@@ -53,7 +53,7 @@ export const UserDataProvider = ({ children }: UserDataProviderProps) => {
   );
 };
 
-// 대시보드 데이터를 사용하기 위한 Hook
+// 유저 데이터를 사용하기 위한 Hook
 export const useUserData = () => {
   const context = useContext(UserDataContext);
   if (context === undefined) {


### PR DESCRIPTION
중복된 이메일 초대시 alert 알림과 함께 리퀘스트가 안넘어가게 구현했습니다


<img width="918" alt="스크린샷 2024-06-13 오후 5 18 55" src="https://github.com/codeit-project-9/taskify/assets/159985297/528089c7-b675-4204-a53d-d7a8b4dd797e">


<img width="937" alt="스크린샷 2024-06-13 오후 5 28 04" src="https://github.com/codeit-project-9/taskify/assets/159985297/7180f52b-f33c-4f1d-a5b9-2cdd61abb70b"></br>
<img width="852" alt="스크린샷 2024-06-13 오후 5 30 43" src="https://github.com/codeit-project-9/taskify/assets/159985297/04e0b3ef-404c-4727-b794-d8586ed81ea7"></br>
대시보드 이름 및 닉네임 요약
