### PR TITLE
fix: 초대내역 수락 시 대시보드 리스트 배치 오류 수정 및 대시보드 상세페이지 접속 시 사이드바 스타일 적용

### DIFF
--- a/src/app/(dashboard)/dashboard/[dashboardid]/edit/page.tsx
+++ b/src/app/(dashboard)/dashboard/[dashboardid]/edit/page.tsx
@@ -5,6 +5,7 @@ import InvitationList from '@/app/components/InvitationList';
 import MemberList from '@/app/components/MemberList';
 import UpdateDashboardName from '@/app/components/UpdateDashboardName';
 import SettingChangedModal from '@/app/components/modals/SettingChangedModal';
+import { useDashboardData } from '@/context/DashboardDataContext';
 import { useModal } from '@/context/ModalContext';
 import { useRouter } from 'next/navigation';
 
@@ -17,6 +18,7 @@ interface PageProps {
 export default function dashboardEditPage({ params }: PageProps) {
   const router = useRouter();
   const { dashboardid } = params;
+  const { dashboardsData, setDashboardsData } = useDashboardData();
   const backLink = `/dashboard/${dashboardid}`; // 동적 파라미터를 포함한 링크 생성
 
   const { openModal } = useModal();
@@ -34,6 +36,8 @@ export default function dashboardEditPage({ params }: PageProps) {
           <SettingChangedModal>대시보드가 삭제되었습니다.</SettingChangedModal>,
         );
         router.push('/mydashboard');
+        const response = await instance.delete(`/dashboards`);
+        setDashboardsData(response.data);
       }
     } catch (e: unknown) {
       <SettingChangedModal>

--- a/src/app/(dashboard)/mydashboard/page.tsx
+++ b/src/app/(dashboard)/mydashboard/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useDashboardId } from '@/context/DashBoardIdContext';
 import DashboardCard from '@/app/components/DashboardCard';
 import InvitedDashboardListMobile from '@/app/components/InvitedDashboardListMobile';
 import InvitedDashboardList from '@/app/components/InvitedDashboarList';
 
 const MyDashboard = () => {
   const [isMobile, setIsMobile] = useState(false);
+  const { setDashboardID } = useDashboardId();
 
   useEffect(() => {
     if (typeof window !== 'undefined') {
@@ -15,7 +17,7 @@ const MyDashboard = () => {
       };
 
       handleResize();
-
+      setDashboardID(0);
       window.addEventListener('resize', handleResize);
 
       return () => {

--- a/src/app/(dashboard)/mypage/page.tsx
+++ b/src/app/(dashboard)/mypage/page.tsx
@@ -1,8 +1,17 @@
+'use client';
+
 import BackButton from '@/app/components/BackButton';
 import ProfileSetting from '@/app/components/ProfileSetting';
 import PasswordChangeForm from '@/app/components/PasswordChangeForm';
+import { useDashboardId } from '@/context/DashBoardIdContext';
+import { useEffect } from 'react';
 
 export default function MyPage() {
+  const { setDashboardID } = useDashboardId();
+  useEffect(() => {
+    setDashboardID(0);
+  }, []);
+
   return (
     <>
       <div className='flex'>

--- a/src/app/components/DashboardList.tsx
+++ b/src/app/components/DashboardList.tsx
@@ -67,7 +67,7 @@ export default function DashboardList() {
       setTotalCount(res.data.totalCount);
     };
     fetchdashboardData();
-  }, [currentPage]);
+  }, [currentPage, dashboardID]);
 
   return (
     <div className='p-0 max-sm:hidden'>

--- a/src/app/components/DashboardList.tsx
+++ b/src/app/components/DashboardList.tsx
@@ -7,7 +7,9 @@ import Image from 'next/image';
 import { useModal } from '@/context/ModalContext';
 import NewDashboardModal from './modals/NewDashboardModal';
 import { useDashboardData } from '@/context/DashboardDataContext';
+import { useDashboardId } from '@/context/DashBoardIdContext';
 import instance from '@/app/api/axios';
+import clsx from 'clsx'; // 조건부 스타일링 라이브러리
 
 type ColorPalette = {
   [key: string]: string;
@@ -28,6 +30,7 @@ export default function DashboardList() {
   const { openModal } = useModal();
   const startIndex = (currentPage - 1) * 10; //시작페이지
   const totalPage = Math.ceil(totalCount / 10); //마지막페이지
+  const { dashboardID } = useDashboardId();
 
   /** 대시보드 조회 파라미터 */
   const queryParams = {
@@ -67,8 +70,8 @@ export default function DashboardList() {
   }, [currentPage]);
 
   return (
-    <div className='p-0 px-3 max-sm:hidden'>
-      <div className='font-Pretendard mx-3 mb-8 mt-16 flex items-center justify-between font-bold text-gray-500'>
+    <div className='p-0 max-sm:hidden'>
+      <div className='font-Pretendard mx-3 mb-8 mt-16 flex items-center justify-between px-3 font-bold text-gray-500'>
         <div className='font-pretendard text-xs font-bold text-custom_black-_333236 max-sm:hidden'>
           Dash Boards
         </div>
@@ -83,28 +86,37 @@ export default function DashboardList() {
       </div>
       <div>
         {dashboardsData.map((todo) => (
-          <Link
+          <div
             key={todo.id}
-            href={`/dashboard/${todo.id}`}
-            className='font-Pretendard my-7 flex items-center gap-4 font-medium text-custom_black-_333236 max-sm:justify-center'
+            className={clsx('px-3', {
+              'bg-custom_gray-_eeeeee': Number(todo.id) === dashboardID, // todo.id와 현재 대시보드 id값이 같으면 배경색 추가
+            })}
           >
-            <div
-              className={`h-2 w-2 rounded-full ${ColorPalette[todo.color]}`}
-            />
-            <div className='w-[80px] truncate max-sm:hidden'>{todo.title}</div>
-            {todo.createdByMe && (
-              <div className='relative h-3.5 w-5 max-sm:hidden'>
-                <Image
-                  fill
-                  src='/images/createByMe.svg'
-                  alt='내가 만든 대시보드'
-                />
+            <Link
+              key={todo.id}
+              href={`/dashboard/${todo.id}`}
+              className='font-Pretendard flex items-center gap-4 py-[14px] font-medium text-custom_black-_333236 max-sm:justify-center'
+            >
+              <div
+                className={`h-2 w-2 rounded-full ${ColorPalette[todo.color]}`}
+              />
+              <div className='w-[80px] truncate max-sm:hidden'>
+                {todo.title}
               </div>
-            )}
-          </Link>
+              {todo.createdByMe && (
+                <div className='relative h-3.5 w-5 max-sm:hidden'>
+                  <Image
+                    fill
+                    src='/images/createByMe.svg'
+                    alt='내가 만든 대시보드'
+                  />
+                </div>
+              )}
+            </Link>
+          </div>
         ))}
       </div>
-      <div className='max-sm:hidden'>
+      <div className='px-3 max-sm:hidden'>
         <Pagination
           currentPage={currentPage}
           totalPage={totalPage}

--- a/src/app/components/DashboardListMobile.tsx
+++ b/src/app/components/DashboardListMobile.tsx
@@ -2,8 +2,11 @@
 import Link from 'next/link';
 import { useEffect, useRef, useState } from 'react';
 import { useModal } from '@/context/ModalContext';
+import { useDashboardData } from '@/context/DashboardDataContext';
+import { useDashboardId } from '@/context/DashBoardIdContext';
 import NewDashboardModal from './modals/NewDashboardModal';
 import instance from '@/app/api/axios';
+import clsx from 'clsx'; // 조건부 스타일링 라이브러리
 
 type ColorPalette = {
   [key: string]: string;
@@ -27,11 +30,13 @@ type DashboardData = {
 export default function DashboardListMobile() {
   const [currentPage, setCurrentPage] = useState<number>(1);
   const [totalCount, setTotalCount] = useState<number>(10);
+  const { dashboardsData, setDashboardsData } = useDashboardData();
   const startPointRef = useRef(0);
+  const nameRef = useRef<HTMLDivElement | null>(null);
   const { openModal } = useModal();
-  const [dashboardsData, setDashboardsData] = useState<DashboardData[]>([]);
   const startIndex = (currentPage - 1) * 10; //시작페이지
   const totalPage = Math.ceil(totalCount / 10); //마지막페이지
+  const { dashboardID } = useDashboardId();
 
   /** 대시보드 조회 파라미터 */
   const queryParams = {
@@ -73,8 +78,8 @@ export default function DashboardListMobile() {
   }, [currentPage]);
 
   return (
-    <div className='p-0 px-3 sm:hidden'>
-      <div className='mx-2 mb-8 mt-16 flex items-center justify-between'>
+    <div className='p-0 sm:hidden'>
+      <div className='mx-2 mb-8 mt-16 flex items-center justify-between px-3'>
         <button>
           <img
             className='h-5 w-5'
@@ -86,15 +91,23 @@ export default function DashboardListMobile() {
       </div>
       <div onTouchStart={handleTouchStart} onTouchEnd={handleTouchEnd}>
         {dashboardsData.map((todo) => (
-          <Link
+          <div
             key={todo.id}
-            href={`/dashboard/${todo.id}`}
-            className='my-7 flex items-center justify-center'
+            ref={nameRef}
+            className={clsx('px-3', {
+              'bg-custom_gray-_eeeeee': Number(todo.id) === dashboardID, // todo.id와 현재 대시보드 id값이 같으면 배경색 추가
+            })}
           >
-            <div
-              className={`h-2 w-2 rounded-full ${ColorPalette[todo.color]}`}
-            />
-          </Link>
+            <Link
+              key={todo.id}
+              href={`/dashboard/${todo.id}`}
+              className='flex items-center justify-center py-[14px]'
+            >
+              <div
+                className={`h-2 w-2 rounded-full ${ColorPalette[todo.color]}`}
+              />
+            </Link>
+          </div>
         ))}
       </div>
     </div>

--- a/src/app/components/InvitedDashboarList.tsx
+++ b/src/app/components/InvitedDashboarList.tsx
@@ -142,7 +142,9 @@ const InvitedDashboardList = () => {
             }
           });
 
-          return newData;
+          const slicedData = newData.slice(0, 10);
+
+          return slicedData;
         });
         router.push(`/dashboard/${dashboardRes.data.id}`);
       }

--- a/src/app/components/InvitedDashboarList.tsx
+++ b/src/app/components/InvitedDashboarList.tsx
@@ -123,14 +123,25 @@ const InvitedDashboardList = () => {
       setFilteredInvitations((prev) =>
         prev.filter((invitation) => invitation.id !== invitationId),
       );
+      /** 수락했을 시 */
       if (inviteAccepted) {
         const dashboardRes = await instance.get(
           `/dashboards/${res.data.dashboard.id}`,
         );
         setDashboardsData((prev) => {
-          const newData = [...prev];
-          newData.pop();
-          newData.unshift(dashboardRes.data);
+          const newData = [];
+          prev.forEach((item) => {
+            if (item.createdByMe) {
+              newData.push(item);
+            }
+          });
+          newData.push(dashboardRes.data);
+          prev.forEach((item) => {
+            if (!item.createdByMe) {
+              newData.push(item);
+            }
+          });
+
           return newData;
         });
         router.push(`/dashboard/${dashboardRes.data.id}`);

--- a/src/app/components/InvitedDashboardListMobile.tsx
+++ b/src/app/components/InvitedDashboardListMobile.tsx
@@ -127,9 +127,19 @@ const InvitedDashboardListMobile = () => {
           `/dashboards/${res.data.dashboard.id}`,
         );
         setDashboardsData((prev) => {
-          const newData = [...prev];
-          newData.pop();
-          newData.unshift(dashboardRes.data);
+          const newData = [];
+          prev.forEach((item) => {
+            if (item.createdByMe) {
+              newData.push(item);
+            }
+          });
+          newData.push(dashboardRes.data);
+          prev.forEach((item) => {
+            if (!item.createdByMe) {
+              newData.push(item);
+            }
+          });
+
           return newData;
         });
 

--- a/src/app/components/InvitedDashboardListMobile.tsx
+++ b/src/app/components/InvitedDashboardListMobile.tsx
@@ -140,7 +140,9 @@ const InvitedDashboardListMobile = () => {
             }
           });
 
-          return newData;
+          const slicedData = newData.slice(0, 10);
+
+          return slicedData;
         });
 
         router.push(`/dashboard/${dashboardRes.data.id}`);

--- a/src/app/components/ProfileSetting.tsx
+++ b/src/app/components/ProfileSetting.tsx
@@ -73,7 +73,11 @@ export default function ProfileSetting() {
     try {
       const response = await instance.put('users/me', formData);
       if (response.status >= 200 && response.status < 300) {
-        setUserData(formData);
+        setUserData((prevUserData: any) => ({
+          ...prevUserData,
+          nickname: formData.nickname,
+          profileImageUrl: formData.profileImageUrl,
+        }));
         handleOpenModal(
           <SettingChangedModal> 프로필이 변경되었습니다. </SettingChangedModal>,
         );

--- a/src/app/components/modals/InvitationModal.tsx
+++ b/src/app/components/modals/InvitationModal.tsx
@@ -42,20 +42,12 @@ const InvitationModal: React.FC = () => {
         },
       );
       if (response.status >= 200 && response.status < 300) {
-        if (invitationData.length >= 5) {
-          setInvitationData((prev) => {
-            const newData = [...prev];
-            newData.pop();
-            newData.unshift(response.data);
-            return newData;
-          });
-        } else {
-          setInvitationData((prev) => {
-            const newData = [...prev];
-            newData.unshift(response.data);
-            return newData;
-          });
-        }
+        setInvitationData((prev) => {
+          const newData = [...prev];
+          newData.pop();
+          newData.unshift(response.data);
+          return newData;
+        });
         closeModal();
       }
     } catch (error) {

--- a/src/context/DashboardDataContext.tsx
+++ b/src/context/DashboardDataContext.tsx
@@ -18,10 +18,6 @@ interface DashboardDataContextType {
   setDashboardsData: React.Dispatch<
     React.SetStateAction<DashboardDataContextProps[]>
   >;
-  dashboardCard: DashboardDataContextProps[];
-  setDashboardCard: React.Dispatch<
-    React.SetStateAction<DashboardDataContextProps[]>
-  >;
 }
 
 // 대시보드 데이터 컨텍스트 생성
@@ -36,17 +32,11 @@ export const DashboardDataProvider = ({
   const [dashboardsData, setDashboardsData] = useState<
     DashboardDataContextProps[]
   >([]);
-  const [dashboardCard, setDashboardCard] = useState<
-    DashboardDataContextProps[]
-  >([]);
-
   return (
     <DashboardDataContext.Provider
       value={{
         dashboardsData,
         setDashboardsData,
-        dashboardCard,
-        setDashboardCard,
       }}
     >
       {children}
@@ -58,9 +48,7 @@ export const DashboardDataProvider = ({
 export const useDashboardData = () => {
   const context = useContext(DashboardDataContext);
   if (context === undefined) {
-    throw new Error(
-      'useDashboardData must be used within a DashboardDataProvider',
-    );
+    throw new Error('대시보드 데이터 사용 불가능!');
   }
   return context;
 };

--- a/src/context/UserDataContext.tsx
+++ b/src/context/UserDataContext.tsx
@@ -10,8 +10,12 @@ import React, {
 } from 'react';
 
 interface UserDataContextProps {
+  id: number;
+  email: string;
   nickname: string;
-  profileImageUrl?: string | undefined;
+  profileImageUrl?: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 interface UserDataProviderProps {


### PR DESCRIPTION
태블릿 및 모바일 사이즈에서 대시보드 제목이 사라지기 때문에 사이드바의 스타일에 변화를 주어 어느 페이지 있는지 알 수 있게 구현했습니다.
초대내역 수락 및 대시보드 삭제 시 사이드바에 제대로 반영 안되는 문제 해결했습니다.

<img width="592" alt="스크린샷 2024-06-14 오후 5 28 22" src="https://github.com/codeit-project-9/taskify/assets/159985297/dce8c5a2-46e9-48a3-9d11-3c7ee8e83471"></br>
사이드바 스타일링 
